### PR TITLE
HC-103: Update create cloud staging area command to support non-signal file based triggers

### DIFF
--- a/sdscli/cloud/aws/storage.py
+++ b/sdscli/cloud/aws/storage.py
@@ -191,7 +191,7 @@ def create_staging_area(args, conf):
         filter_rules = bn_args['NotificationConfiguration']['TopicConfigurations']['Filter']['Key']['FilterRules']
         suffix_filter = {
             'Name': 'suffix',
-            'Value': args.suffix
+            'Value': args.suffix[0]
         }
         filter_rules.append(suffix_filter)
     configure_bucket_notification(bucket_name, c=s3_res, **bn_args)
@@ -299,13 +299,13 @@ def create_staging_area(args, conf):
                 "JOB_TYPE": job_type,
                 "JOB_RELEASE": job_release,
                 "JOB_QUEUE": job_queue,
-                "MOZART_URL": "https://{}/mozart".format(conf.get('MOZART_PVT_IP')),
-                "IS_SIGNAL_FILE": False
+                "MOZART_URL": "https://{}/mozart".format(conf.get('MOZART_PVT_IP'))
             }
         }
     }
     if args.suffix:
-        cf_args["Environment"]["Variables"]["IS_SIGNAL_FILE"] = True
+        cf_args["Environment"]["Variables"]["SIGNAL_FILE_SUFFIX"] = \
+            args.suffix[0]
     lambda_resp = lambda_client.create_function(**cf_args)
     logger.debug("lambda_resp: {}".format(lambda_resp))
 

--- a/sdscli/cloud/aws/storage.py
+++ b/sdscli/cloud/aws/storage.py
@@ -188,7 +188,7 @@ def create_staging_area(args, conf):
         }
     }
     if args.suffix:
-        filter_rules = bn_args['NotificationConfiguration']['TopicConfigurations']['Filter']['Key']['FilterRules']
+        filter_rules = bn_args['NotificationConfiguration']['TopicConfigurations'][0]['Filter']['Key']['FilterRules']
         suffix_filter = {
             'Name': 'suffix',
             'Value': args.suffix[0]

--- a/sdscli/cloud/aws/storage.py
+++ b/sdscli/cloud/aws/storage.py
@@ -191,7 +191,7 @@ def create_staging_area(args, conf):
         filter_rules = bn_args['NotificationConfiguration']['TopicConfigurations'][0]['Filter']['Key']['FilterRules']
         suffix_filter = {
             'Name': 'suffix',
-            'Value': args.suffix[0]
+            'Value': args.suffix
         }
         filter_rules.append(suffix_filter)
     configure_bucket_notification(bucket_name, c=s3_res, **bn_args)

--- a/sdscli/cloud/aws/storage.py
+++ b/sdscli/cloud/aws/storage.py
@@ -305,7 +305,7 @@ def create_staging_area(args, conf):
     }
     if args.suffix:
         cf_args["Environment"]["Variables"]["SIGNAL_FILE_SUFFIX"] = \
-            args.suffix[0]
+            args.suffix
     lambda_resp = lambda_client.create_function(**cf_args)
     logger.debug("lambda_resp: {}".format(lambda_resp))
 

--- a/sdscli/command_line.py
+++ b/sdscli/command_line.py
@@ -444,8 +444,8 @@ def main():
         '--bucket', '-b', default=None, help="bucket name")
     parser_cloud_storage_create_staging_area.add_argument('--prefix', '-p', default="staging_area/",
                                                           help="staging area prefix")
-    parser_cloud_storage_create_staging_area.add_argument('--suffix', '-s', default=".signal.json",
-                                                          help="staging area signal file suffix")
+    parser_cloud_storage_create_staging_area.add_argument(
+        '--suffix', help="staging area signal file suffix")
     parser_cloud.set_defaults(func=cloud)
 
     # parser for user rules


### PR DESCRIPTION
Per my conversations with @pymonger, it was decided that it is safe to no longer make `.signal.json` the `--suffix` flag value default as SWOT was the only one using this capability initially. If a value does get passed into the `--suffix` flag, it will get passed onto the Lambda via an environment variable named `SIGNAL_FILE_SUFFIX`.