### PR TITLE
HC-104: Updated to support a mapping of job types to regexes for ingest lambda

### DIFF
--- a/sdscli/cloud/aws/storage.py
+++ b/sdscli/cloud/aws/storage.py
@@ -340,7 +340,7 @@ def create_staging_area(args, conf):
         }
     }
     if job_types:
-        cf_args["Environment"]["Variables"]["JOB_TYPES"] = job_types
+        cf_args["Environment"]["Variables"]["JOB_TYPES"] = json.dumps(job_types)
 
     if args.suffix:
         cf_args["Environment"]["Variables"]["SIGNAL_FILE_SUFFIX"] = \

--- a/sdscli/cloud/aws/storage.py
+++ b/sdscli/cloud/aws/storage.py
@@ -252,27 +252,63 @@ def create_staging_area(args, conf):
     logger.debug("Selected role: {}".format(role))
 
     # prompt for job type, release, and queue
-    if 'JOB_TYPE' in sa_cfg:
-        job_type = sa_cfg['JOB_TYPE']
+    """
+    TODO: Need to update to support the interactive use-case. 
+    
+    Below is an example of how this could be done to fill out the job 
+    type mapping:
+    
+    values = prompt('Please enter job types to submit on data '
+                    'staged event, separate by space. '
+                    'Leave blank if no mapping is needed: ')
+    value_list = values.split()
+    for type in value_list:
+        regex_value = prompt("Please enter a regex pattern to associate "
+                             "for the '{}' job type: ".format(type))
+        # Need to compile the regex: re.compile(pattern)
+        job_types[type] = re.compile(regex_value)
+    """
+    job_types = {}
+    default_job_type = "INGEST_STAGED"
+    if 'JOB_TYPES' in sa_cfg and 'DEFAULT' in sa_cfg['JOB_TYPES']:
+        default_job_type_info = sa_cfg['JOB_TYPES']['DEFAULT']
+        if 'TYPE' in default_job_type_info:
+            default_job_type = default_job_type_info['TYPE']
+        else:
+            default_job_type = prompt(get_prompt_tokens=lambda x:
+            [(Token, "Enter default job type to submit on data staged event: ")],
+                                      style=prompt_style).strip()
+        logger.debug("default job type: {}".format(default_job_type))
+
+        if 'RELEASE' in default_job_type_info:
+            default_job_release = default_job_type_info['RELEASE']
+        else:
+            default_job_release = prompt(get_prompt_tokens=lambda x:
+            [(Token, "Enter default release version for {}: ".format(
+                default_job_type))], style=prompt_style).strip()
+
+        logger.debug("default job release: {}".format(default_job_release))
+
+        if 'QUEUE' in default_job_type_info:
+            default_job_queue = default_job_type_info['QUEUE']
+        else:
+            default_job_queue = prompt(get_prompt_tokens=lambda x:
+            [(Token,
+              "Enter queue name to submit {}-{} jobs to: ".format(
+                  default_job_type, default_job_release))],
+                               style=prompt_style).strip()
+
+        logger.debug("default job queue: {}".format(default_job_queue))
+
+        if 'TYPES' in sa_cfg['JOB_TYPES']:
+            job_types = sa_cfg['JOB_TYPES']['TYPES']
+
     else:
-        job_type = prompt(get_prompt_tokens=lambda x:
-                          [(Token, "Enter job type to submit on data staged event: ")],
-                          style=prompt_style).strip()
-    logger.debug("job type: {}".format(job_type))
-    if 'JOB_RELEASE' in sa_cfg:
-        job_release = sa_cfg['JOB_RELEASE']
-    else:
-        job_release = prompt(get_prompt_tokens=lambda x:
-                             [(Token, "Enter release version for {}: ".format(job_type))],
-                             style=prompt_style).strip()
-    logger.debug("job release: {}".format(job_release))
-    if 'JOB_QUEUE' in sa_cfg:
-        job_queue = sa_cfg['JOB_QUEUE']
-    else:
-        job_queue = prompt(get_prompt_tokens=lambda x:
-                           [(Token, "Enter queue name to submit {}-{} jobs to: ".format(job_type, job_release))],
-                           style=prompt_style).strip()
-    logger.debug("job queue: {}".format(job_queue))
+        raise RuntimeError("JOB_TYPES area is missing a DEFAULT and an "
+                           "optional TYPES area")
+
+    logger.debug("job types: {}".format(job_types))
+
 
     # create lambda
     function_name = "{}-dataset-{}-submit_ingest".format(conf.get('VENUE'),
@@ -296,13 +332,16 @@ def create_staging_area(args, conf):
         "Environment": {
             "Variables": {
                 "DATASET_S3_ENDPOINT": conf.get('DATASET_S3_ENDPOINT'),
-                "JOB_TYPE": job_type,
-                "JOB_RELEASE": job_release,
-                "JOB_QUEUE": job_queue,
+                "DEFAULT_JOB_TYPE": default_job_type,
+                "DEFAULT_JOB_RELEASE": default_job_release,
+                "DEFAULT_JOB_QUEUE": default_job_queue,
                 "MOZART_URL": "https://{}/mozart".format(conf.get('MOZART_PVT_IP'))
             }
         }
     }
+    if job_types:
+        cf_args["Environment"]["Variables"]["JOB_TYPES"] = job_types
+
     if args.suffix:
         cf_args["Environment"]["Variables"]["SIGNAL_FILE_SUFFIX"] = \
             args.suffix


### PR DESCRIPTION
sdscli was updated to support reading in a new setting in the sds config called `JOB_TYPES` which can be set under the `STAGING_AREA`. This would contain a mapping of job types to a regular expression like so:
```
JOB_TYPES:
  L0A_Prime:
    PATTERN: '.*APID(1070|1071|1072|1073|1074|1075|1280|1408).*'
    QUEUE: job_worker-small
    RELEASE: develop

JOB_TYPE: INGEST_STAGED
JOB_QUEUE: job_worker-small
JOB_RELEASE: develop
```
Note that `JOB_TYPES` is an optional parameter. If it is not specified, sdscli will work the way it normally works. If this parameter is specified, then the lambda will set the appropriate job type that matches the data file in the job type mapping. If nothing matches, then it will set the job type to the default, which is specified in the `JOB_TYPE` setting.