### PR TITLE
restore configuration tool

### DIFF
--- a/sdscli/adapters/__init__.py
+++ b/sdscli/adapters/__init__.py
@@ -8,10 +8,13 @@ from sdscli.log_utils import logger
 from hysds_commons.elasticsearch_utils import ElasticsearchUtility
 
 
-conf = SettingsConf()
-
-_mozart_es_url = "http://{}:9200".format(conf.get('MOZART_ES_PVT_IP'))
-_grq_es_url = "http://{}:9200".format(conf.get('GRQ_ES_PVT_IP'))
-
-mozart_es = ElasticsearchUtility(_mozart_es_url, logger)
-grq_es = ElasticsearchUtility(_grq_es_url, logger)
+try:
+    conf = SettingsConf()
+    
+    _mozart_es_url = "http://{}:9200".format(conf.get('MOZART_ES_PVT_IP'))
+    _grq_es_url = "http://{}:9200".format(conf.get('GRQ_ES_PVT_IP'))
+    
+    mozart_es = ElasticsearchUtility(_mozart_es_url, logger)
+    grq_es = ElasticsearchUtility(_grq_es_url, logger)
+except:
+    pass


### PR DESCRIPTION
Restore sds configuration tool:
```
(mozart) ops@localhost:~$ ls -al ~/.sds
ls: cannot access /home/ops/.sds: No such file or directory
(mozart) ops@localhost:~$ sds configure
Traceback (most recent call last):
  File "/home/ops/mozart/bin/sds", line 11, in <module>
    load_entry_point('sdscli', 'console_scripts', 'sds')()
  File "/home/ops/mozart/ops/sdscli/sdscli/command_line.py", line 546, in main
    return dispatch(args)
  File "/home/ops/mozart/ops/sdscli/sdscli/command_line.py", line 235, in dispatch
    return args.func(args)
  File "/home/ops/mozart/ops/sdscli/sdscli/command_line.py", line 60, in configure
    func = get_adapter_func(sds_type, 'configure', 'configure')
  File "/home/ops/mozart/ops/sdscli/sdscli/command_line.py", line 31, in get_adapter_func
    return get_func(adapter_mod, func_name)
  File "/home/ops/mozart/ops/sdscli/sdscli/func_utils.py", line 35, in get_func
    mod = get_module(mod_name)
  File "/home/ops/mozart/ops/sdscli/sdscli/func_utils.py", line 25, in get_module
    return import_module(mod_name)
  File "/home/ops/mozart/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/ops/mozart/ops/sdscli/sdscli/adapters/__init__.py", line 11, in <module>
    conf = SettingsConf()
  File "/home/ops/mozart/ops/sdscli/sdscli/conf_utils.py", line 70, in __init__
    super(SettingsConf, self).__init__(file)
  File "/home/ops/mozart/ops/sdscli/sdscli/conf_utils.py", line 44, in __init__
    with open(self._file) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/ops/.sds/config'
```
