### PR TITLE
refactored es code to reflect changes to ElasticsearchUtility

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/__init__.py
+++ b/sdscli/adapters/__init__.py
@@ -4,17 +4,8 @@ from __future__ import division
 from __future__ import absolute_import
 
 from sdscli.conf_utils import SettingsConf
-from sdscli.log_utils import logger
-from hysds_commons.elasticsearch_utils import ElasticsearchUtility
-
 
 try:
     conf = SettingsConf()
-    
-    _mozart_es_url = "http://{}:9200".format(conf.get('MOZART_ES_PVT_IP'))
-    _grq_es_url = "http://{}:9200".format(conf.get('GRQ_ES_PVT_IP'))
-    
-    mozart_es = ElasticsearchUtility(_mozart_es_url, logger)
-    grq_es = ElasticsearchUtility(_grq_es_url, logger)
-except:
+except Exception as e:
     pass

--- a/sdscli/adapters/hysds/rules.py
+++ b/sdscli/adapters/hysds/rules.py
@@ -12,27 +12,23 @@ import json
 
 from sdscli.log_utils import logger
 from sdscli.os_utils import validate_dir, normpath
-from sdscli.adapters import mozart_es
+from hysds.es_utils import get_mozart_es
 
 USER_RULES_MOZART = 'user_rules-mozart'
 USER_RULES_GRQ = 'user_rules-grq'
 
+mozart_es = get_mozart_es()
+
 
 def export(args):
     """Export HySDS user rules."""
-    query = {
-        "query": {
-            "match_all": {}
-        }
-    }
-
     rules = {}
 
-    mozart_rules = mozart_es.query(USER_RULES_MOZART, query)
+    mozart_rules = mozart_es.query(index=USER_RULES_MOZART)
     rules['mozart'] = [rule['_source'] for rule in mozart_rules]
     logger.debug('%d mozart user rules found' % len(mozart_rules))
 
-    grq_rules = mozart_es.query(USER_RULES_MOZART, query)
+    grq_rules = mozart_es.query(index=USER_RULES_MOZART)
     rules['grq'] = [rule['_source'] for rule in grq_rules]
     logger.debug('%d grq user rules found' % len(grq_rules))
 
@@ -69,9 +65,9 @@ def import_rules(args):
     logger.debug("rules: {}".format(json.dumps(rules_file, indent=2, sort_keys=True)))
 
     for rule in user_rules['mozart']:
-        result = mozart_es.index_document(USER_RULES_MOZART, rule)  # indexing mozart rules
+        result = mozart_es.index_document(index=USER_RULES_MOZART, body=rule)  # indexing mozart rules
         logger.debug(result)
 
     for rule in user_rules['grq']:
-        result = mozart_es.index_document(USER_RULES_GRQ, rule)  # indexing GRQ rules
+        result = mozart_es.index_document(index=USER_RULES_GRQ, body=rule)  # indexing GRQ rules
         logger.debug(result)


### PR DESCRIPTION
https://hysds-core.atlassian.net/browse/HC-199
- refactoring `hysds_common`'s `ElasticsearchUtility` to allow for more flexibility
- re-using hysds core's elasticsearch connection because it allows us to read/write to AWS elasticsearch (defined in `.sds/config` and `celeryconfig.py`)
- `lightweight-jobs` will use hysds-core's ES connection

https://github.com/hysds/hysds_commons/pull/26/files#diff-0177d5302571ecb822b51229be69453d

tested `on-demand` and `user_rules` processing in both tosca and figaro