### PR TITLE
fixed es util import

### DIFF
--- a/sdscli/adapters/hysds/pkg.py
+++ b/sdscli/adapters/hysds/pkg.py
@@ -17,7 +17,7 @@ from sdscli.conf_utils import get_user_files_path, SettingsConf
 from sdscli.os_utils import validate_dir, normpath
 
 from osaka.main import get, put, rmall
-from hysds.es_utils import get_mozart_es
+from hysds.es_util import get_mozart_es
 
 CONTAINERS_INDEX = "containers"
 JOB_SPECS_INDEX = "job_specs"

--- a/sdscli/adapters/hysds/rules.py
+++ b/sdscli/adapters/hysds/rules.py
@@ -12,7 +12,7 @@ import json
 
 from sdscli.log_utils import logger
 from sdscli.os_utils import validate_dir, normpath
-from hysds.es_utils import get_mozart_es
+from hysds.es_util import get_mozart_es
 
 USER_RULES_MOZART = 'user_rules-mozart'
 USER_RULES_GRQ = 'user_rules-grq'


### PR DESCRIPTION
fixed import error
```
module.common.aws_instance.mozart (remote-exec): [2020-05-06 17:58:45,477: DEBUG/sdscli/dispatch] args: Namespace(debug=True, file='container-hysds_lightweight-jobs-v1.0.1.sdspkg.tar', func=<function pkg at 0x7f3f819bec20>, subparser='import', type='hysds')
module.common.aws_instance.mozart (remote-exec): [2020-05-06 17:58:45,522: DEBUG/sdscli/pkg] got to pkg(): Namespace(debug=True, file='container-hysds_lightweight-jobs-v1.0.1.sdspkg.tar', func=<function pkg at 0x7f3f819bec20>, subparser='import', type='hysds')
module.common.aws_instance.mozart (remote-exec): [2020-05-06 17:58:45,522: DEBUG/sdscli/pkg] sds_type: hysds
module.common.aws_instance.mozart (remote-exec): [2020-05-06 17:58:45,523: DEBUG/sdscli/__init__] file: /export/home/****/.sds/config
module.common.aws_instance.mozart (remote-exec): [2020-05-06 17:58:46,389: ERROR/sdscli/get_module] Failed to import module "sdscli.adapters.hysds.pkg".
module.common.aws_instance.mozart (remote-exec): [2020-05-06 17:58:46,390: ERROR/sdscli/get_module] Traceback (most recent call last):
module.common.aws_instance.mozart (remote-exec):   File "/export/home/****/mozart/ops/sdscli/sdscli/func_utils.py", line 25, in get_module
module.common.aws_instance.mozart (remote-exec):     return import_module(mod_name)
module.common.aws_instance.mozart (remote-exec):   File "/export/home/****/mozart/lib/python3.7/importlib/__init__.py", line 127, in import_module
module.common.aws_instance.mozart (remote-exec):     return _bootstrap._gcd_import(name[level:], package, level)
module.common.aws_instance.mozart (remote-exec):   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
module.common.aws_instance.mozart (remote-exec):   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
module.common.aws_instance.mozart (remote-exec):   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
module.common.aws_instance.mozart (remote-exec):   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
module.common.aws_instance.mozart (remote-exec):   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
module.common.aws_instance.mozart (remote-exec):   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
module.common.aws_instance.mozart (remote-exec):   File "/export/home/****/mozart/ops/sdscli/sdscli/adapters/hysds/pkg.py", line 20, in <module>
module.common.aws_instance.mozart (remote-exec):     from hysds.es_utils import get_mozart_es
module.common.aws_instance.mozart (remote-exec): ModuleNotFoundError: No module named 'hysds.es_utils'
module.common.aws_instance.mozart (remote-exec): [2020-05-06 17:58:46,390: ERROR/sdscli/get_adapter_func] Failed to import adapter module "pkg" for SDS type "hysds".
module.common.aws_instance.mozart (remote-exec): [2020-05-06 17:58:46,390: ERROR/sdscli/get_adapter_func] Not implemented yet. Mahalo for trying. ;)
```