### PR TITLE
ignore=404 to sds pkg rm

### DIFF
--- a/sdscli/adapters/hysds/pkg.py
+++ b/sdscli/adapters/hysds/pkg.py
@@ -261,7 +261,7 @@ def rm(args):
     """Remove HySDS package."""
     cont_id = args.id  # container id
 
-    cont_info = mozart_es.get_by_id(index=CONTAINERS_INDEX, id=cont_id, safe=True)  # query for container
+    cont_info = mozart_es.get_by_id(index=CONTAINERS_INDEX, id=cont_id, ignore=404)  # query for container
     if cont_info['found'] is False:
         logger.error("SDS package id {} not found.".format(cont_id))
         return 1


### PR DESCRIPTION
```
$ sds pkg rm container-iems-sds_nisar-pcm:nsds-689
[2020-05-19 00:56:49,906: ERROR/hysds.log_utils/get_by_id] get() got an unexpected keyword argument 'safe'
Traceback (most recent call last):
  File "/export/home/hysdsops/mozart/ops/hysds_commons/hysds_commons/elasticsearch_utils.py", line 55, in get_by_id
    data = self.es.get(**kwargs)
  File "/export/home/hysdsops/mozart/lib/python3.7/site-packages/elasticsearch/client/utils.py", line 92, in _wrapped
    return func(*args, params=params, headers=headers, **kwargs)
TypeError: get() got an unexpected keyword argument 'safe'
Traceback (most recent call last):
  File "/export/home/hysdsops/mozart/bin/sds", line 11, in <module>
    load_entry_point('sdscli', 'console_scripts', 'sds')()
  File "/export/home/hysdsops/mozart/ops/sdscli/sdscli/command_line.py", line 546, in main
    return dispatch(args)
  File "/export/home/hysdsops/mozart/ops/sdscli/sdscli/command_line.py", line 235, in dispatch
    return args.func(args)
  File "/export/home/hysdsops/mozart/ops/sdscli/sdscli/command_line.py", line 173, in pkg
    func(args)
  File "/export/home/hysdsops/mozart/ops/sdscli/sdscli/adapters/hysds/pkg.py", line 264, in rm
    cont_info = mozart_es.get_by_id(index=CONTAINERS_INDEX, id=cont_id, safe=True)  # query for container
  File "/export/home/hysdsops/mozart/ops/hysds_commons/hysds_commons/elasticsearch_utils.py", line 68, in get_by_id
    raise e
  File "/export/home/hysdsops/mozart/ops/hysds_commons/hysds_commons/elasticsearch_utils.py", line 55, in get_by_id
    data = self.es.get(**kwargs)
  File "/export/home/hysdsops/mozart/lib/python3.7/site-packages/elasticsearch/client/utils.py", line 92, in _wrapped
    return func(*args, params=params, headers=headers, **kwargs)
TypeError: get() got an unexpected keyword argument 'safe'
```