### PR TITLE
added timestamp for missing timestamps when importing rules, bump version

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/rules.py
+++ b/sdscli/adapters/hysds/rules.py
@@ -9,6 +9,7 @@ standard_library.install_aliases()
 
 import os
 import json
+from datetime import datetime
 
 from sdscli.log_utils import logger
 from sdscli.os_utils import validate_dir, normpath
@@ -65,9 +66,23 @@ def import_rules(args):
     logger.debug("rules: {}".format(json.dumps(rules_file, indent=2, sort_keys=True)))
 
     for rule in user_rules['mozart']:
+        now = datetime.utcnow().isoformat() + 'Z'
+
+        if not rule.get('creation_time', None):
+            rule['creation_time'] = now
+        if not rule.get('modified_time', None):
+            rule['modified_time'] = now
+
         result = mozart_es.index_document(index=USER_RULES_MOZART, body=rule)  # indexing mozart rules
         logger.debug(result)
 
     for rule in user_rules['grq']:
+        now = datetime.utcnow().isoformat() + 'Z'
+
+        if not rule.get('creation_time', None):
+            rule['creation_time'] = now
+        if not rule.get('modified_time', None):
+            rule['modified_time'] = now
+
         result = mozart_es.index_document(index=USER_RULES_GRQ, body=rule)  # indexing GRQ rules
         logger.debug(result)


### PR DESCRIPTION
after importing rules
```
$ cd ~/.sds/files/test
$ ./import_rules-mozart.sh
[2020-05-25 17:20:58,982: DEBUG/sdscli/dispatch] args: Namespace(debug=True, file='/tmp/user_rules.json.6953', func=<function rules at 0x7f6d3eb39cb0>, subparser='import', type='hysds')
[2020-05-25 17:20:58,983: DEBUG/sdscli/rules] got to pkg(): Namespace(debug=True, file='/tmp/user_rules.json.6953', func=<function rules at 0x7f6d3eb39cb0>, subparser='import', type='hysds')
[2020-05-25 17:20:58,983: DEBUG/sdscli/rules] sds_type: hysds
[2020-05-25 17:20:58,983: DEBUG/sdscli/__init__] file: /export/home/hysdsops/.sds/config
[2020-05-25 17:20:59,325: DEBUG/sdscli/get_func] mod: <module 'sdscli.adapters.hysds.rules' from '/export/home/hysdsops/mozart/ops/sdscli/sdscli/adapters/hysds/rules.py'>
[2020-05-25 17:20:59,325: DEBUG/sdscli/get_func] func_name: import_rules
[2020-05-25 17:20:59,325: DEBUG/sdscli/rules] func: <function import_rules at 0x7f6d2fe60b00>
[2020-05-25 17:20:59,325: DEBUG/sdscli/import_rules] rules_file: /tmp/user_rules.json.6953
[2020-05-25 17:20:59,326: DEBUG/sdscli/import_rules] rules: "/tmp/user_rules.json.6953"
[2020-05-25 17:20:59,336: DEBUG/sdscli/import_rules] {'_index': 'user_rules-mozart', '_type': '_doc', '_id': '6jjaTHIBSqu8TM78ETrA', '_version': 1, 'result': 'created', '_shards': {'total': 2, 'successful': 1, 'failed': 0}, '_seq_no': 12, '_primary_term': 2}
[2020-05-25 17:20:59,345: DEBUG/sdscli/import_rules] {'_index': 'user_rules-mozart', '_type': '_doc', '_id': '6zjaTHIBSqu8TM78ETrK', '_version': 1, 'result': 'created', '_shards': {'total': 2, 'successful': 1, 'failed': 0}, '_seq_no': 13, '_primary_term': 2}
```
<img width="1789" alt="Screen Shot 2020-05-25 at 10 21 21 AM" src="https://user-images.githubusercontent.com/13371881/82833071-dd543d80-9e71-11ea-8e40-8c1d1f6ca0fb.png">
