### PR TITLE
HC-287: Make heap settings in the jvm.options file configurable

### DIFF
--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -834,9 +834,9 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
 
 def send_logstash_jvm_options(node_type):
     ctx = get_context(node_type)
-    ram_size_gb = int(get_ram_size_bytes())/1024**3
+    ram_size_gb = int(get_ram_size_bytes())//1024**3
     echo("instance RAM size: {}GB".format(ram_size_gb))
-    ram_size_gb_half = int(ram_size_gb/2)
+    ram_size_gb_half = int(ram_size_gb//2)
     ctx['LOGSTASH_HEAP_SIZE'] = 8 if ram_size_gb_half >= 8 else ram_size_gb_half
     echo("configuring logstash heap size: {}GB".format(ctx['LOGSTASH_HEAP_SIZE']))
     upload_template('jvm.options', '~/logstash/config/jvm.options',

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -182,6 +182,10 @@ def fqdn():
     run('hostname --fqdn')
 
 
+def get_ram_size_bytes():
+    return run("free -b | grep ^Mem: | awk '{print $2}'")
+
+
 def yum_update():
     sudo('yum -y -q update')
 
@@ -827,6 +831,21 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
     else:
         raise RuntimeError("Unknown node type: %s" % node_type)
 
+
+def send_logstash_jvm_options(node_type):
+    ctx = get_context(node_type)
+    ram_size_gb = int(get_ram_size_bytes())/1024**3
+    echo("instance RAM size: {}GB".format(ram_size_gb))
+    ram_size_gb_half = int(ram_size_gb/2)
+    ctx['LOGSTASH_HEAP_SIZE'] = 8 if ram_size_gb_half >= 8 else ram_size_gb_half
+    echo("configuring logstash heap size: {}GB".format(ctx['LOGSTASH_HEAP_SIZE']))
+    upload_template('jvm.options', '~/logstash/config/jvm.options',
+                    use_jinja=True, context=ctx, template_dir=get_user_files_path())
+
+
+##########################
+# hysds config functions
+##########################
 
 def send_celeryconf(node_type):
     ctx = get_context(node_type)

--- a/sdscli/adapters/hysds/files/jvm.options
+++ b/sdscli/adapters/hysds/files/jvm.options
@@ -3,8 +3,8 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
--Xms8g
--Xmx8g
+-Xms{{ LOGSTASH_HEAP_SIZE }}g
+-Xmx{{ LOGSTASH_HEAP_SIZE }}g
 
 ################################################################
 ## Expert settings

--- a/sdscli/adapters/hysds/update.py
+++ b/sdscli/adapters/hysds/update.py
@@ -73,8 +73,7 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
 
         # update logstash jvm.options to increase heap size
         set_bar_desc(bar, 'Updating logstash jvm.options')
-        execute(fab.send_template, 'jvm.options',
-                '~/logstash/config/jvm.options', roles=[comp])
+        execute(fab.send_logstash_jvm_options, roles=[comp])
         bar.update()
 
         # update celery config
@@ -312,8 +311,7 @@ def update_metrics(conf, ndeps=False, config_only=False, comp='metrics'):
 
         # update logstash jvm.options to increase heap size
         set_bar_desc(bar, 'Updating logstash jvm.options')
-        execute(fab.send_template, 'jvm.options',
-                '~/logstash/config/jvm.options', roles=[comp])
+        execute(fab.send_logstash_jvm_options, roles=[comp])
         bar.update()
 
         # update celery config

--- a/sdscli/adapters/hysds/update.py
+++ b/sdscli/adapters/hysds/update.py
@@ -73,7 +73,7 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
 
         # update logstash jvm.options to increase heap size
         set_bar_desc(bar, 'Updating logstash jvm.options')
-        execute(fab.send_logstash_jvm_options, roles=[comp])
+        execute(fab.send_logstash_jvm_options, 'mozart', roles=[comp])
         bar.update()
 
         # update celery config
@@ -311,7 +311,7 @@ def update_metrics(conf, ndeps=False, config_only=False, comp='metrics'):
 
         # update logstash jvm.options to increase heap size
         set_bar_desc(bar, 'Updating logstash jvm.options')
-        execute(fab.send_logstash_jvm_options, roles=[comp])
+        execute(fab.send_logstash_jvm_options, 'metrics', roles=[comp])
         bar.update()
 
         # update celery config


### PR DESCRIPTION
Currently, the logstash `jvm.options` file has the heap size setting hard-coded to 8GB. This will cause logstash to fail in cases where the instance has less than 8GB of RAM.
This PR updates the provisioning of the logstash `jvm.options` file to metrics and mozart components so that:
- the RAM size of the instance is detected
- if half of this RAM size is greater than 8GB, then the logstash heap size will be set to 8GB
- otherwise, we set the logstash heap size to half of the RAM size
- heap size determination is guided by the documentation at https://www.elastic.co/guide/en/logstash/7.x/jvm-settings.html

This feature was manually tested and verified on a NISAR dev cluster:

- mozart
```
$ sds -d update mozart -f
...
[xxx.xxx.xxx.xxx] Executing task 'send_logstash_jvm_options'
[xxx.xxx.xxx.xxx] run: free -b | grep ^Mem: | awk '{print $2}'
[xxx.xxx.xxx.xxx] out: 33080537088
[xxx.xxx.xxx.xxx] out: 

[xxx.xxx.xxx.xxx] run: echo "instance RAM size: 30GB"
[xxx.xxx.xxx.xxx] out: instance RAM size: 30GB
[xxx.xxx.xxx.xxx] out: 

[xxx.xxx.xxx.xxx] run: echo "configuring logstash heap size: 8GB"
[xxx.xxx.xxx.xxx] out: configuring logstash heap size: 8GB
[xxx.xxx.xxx.xxx] out: 

[xxx.xxx.xxx.xxx] run: cp "$(echo ~/logstash/config/jvm.options)"{,.bak}
[xxx.xxx.xxx.xxx] put: <file obj> -> /export/home/hysdsops/logstash/config/jvm.options
```
```
(mozart) hysdsops@nisar-xxx-xxx-xxx-xxx: ~$ head ~/logstash/config/jvm.options
## JVM configuration

# Xms represents the initial size of total heap space
# Xmx represents the maximum size of total heap space

-Xms8g
-Xmx8g

################################################################
## Expert settings
```

- metrics
```
$ sds -d update metrics -f
...
[xxx.xxx.xxx.xxx] Executing task 'send_logstash_jvm_options'
[xxx.xxx.xxx.xxx] run: free -b | grep ^Mem: | awk '{print $2}'
[xxx.xxx.xxx.xxx] out: 7831887872
[xxx.xxx.xxx.xxx] out: 

[xxx.xxx.xxx.xxx] run: echo "instance RAM size: 7GB"
[xxx.xxx.xxx.xxx] out: instance RAM size: 7GB
[xxx.xxx.xxx.xxx] out: 

[xxx.xxx.xxx.xxx] run: echo "configuring logstash heap size: 3GB"
[xxx.xxx.xxx.xxx] out: configuring logstash heap size: 3GB
[xxx.xxx.xxx.xxx] out: 

[xxx.xxx.xxx.xxx] run: cp "$(echo ~/logstash/config/jvm.options)"{,.bak}
[xxx.xxx.xxx.xxx] put: <file obj> -> /export/home/hysdsops/logstash/config/jvm.options
```
```
(metrics) [hysdsops@nisar-xxx-xxx-xxx-xxx ~]$ head ~/logstash/config/jvm.options
## JVM configuration

# Xms represents the initial size of total heap space
# Xmx represents the maximum size of total heap space

-Xms3g
-Xmx3g

################################################################
## Expert settings
```