### PR TITLE
HC-273: provision SDSWatch client on PCM components: mozart, metrics, and grq

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -943,6 +943,25 @@ def create_hysds_ios_index():
             run('./create_hysds_ios_index.py')
 
 
+def send_hysds_scripts(node_type):
+    role, hysds_dir, hostname = resolve_role()
+
+    if node_type == 'mozart':
+        send_template("run_docker_registry.sh", "~/mozart/bin/run_docker_registry.sh")
+        run("chmod 755 ~/mozart/bin/run_docker_registry.sh")
+    elif node_type == 'metrics':
+        send_template("run_docker_registry.sh", "~/metrics/bin/run_docker_registry.sh")
+        run("chmod 755 ~/metrics/bin/run_docker_registry.sh")
+    elif node_type == 'grq':
+        send_template("run_docker_registry.sh", "~/sciflo/bin/run_docker_registry.sh")
+        run("chmod 755 ~/sciflo/bin/run_docker_registry.sh")
+    elif node_type in ('verdi', 'verdi-asg', 'factotum'):
+        send_template("run_docker_registry.sh", "~/verdi/bin/run_docker_registry.sh")
+        run("chmod 755 ~/verdi/bin/run_docker_registry.sh")
+    else:
+        raise RuntimeError("Unknown node type: %s" % node_type)
+
+
 ##########################
 # self-signed SSL certs
 ##########################

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -815,6 +815,8 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         upload_template('sdswatch_client-pcm.conf', '~/mozart/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
+        send_template("run_sdswatch_client.sh", "~/mozart/bin/run_sdswatch_client.sh")
+        run("chmod 755 ~/mozart/bin/run_sdswatch_client.sh")
     elif node_type == 'metrics':
         upload_template('indexer.conf.metrics', '~/metrics/etc/indexer.conf', use_jinja=True, context=ctx,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
@@ -828,12 +830,18 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         upload_template('sdswatch_client-pcm.conf', '~/metrics/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
+        send_template("run_sdswatch_client.sh", "~/metrics/bin/run_sdswatch_client.sh")
+        run("chmod 755 ~/metrics/bin/run_sdswatch_client.sh")
     elif node_type == 'grq':
         upload_template('sdswatch_client-pcm.conf', '~/sciflo/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
+        send_template("run_sdswatch_client.sh", "~/sciflo/bin/run_sdswatch_client.sh")
+        run("chmod 755 ~/sciflo/bin/run_sdswatch_client.sh")
     elif node_type in ('verdi', 'verdi-asg', 'factotum'):
         upload_template('sdswatch_client.conf', '~/verdi/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
+        send_template("run_sdswatch_client.sh", "~/verdi/bin/run_sdswatch_client.sh")
+        run("chmod 755 ~/verdi/bin/run_sdswatch_client.sh")
     else:
         raise RuntimeError("Unknown node type: %s" % node_type)
 

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -813,7 +813,7 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         upload_template('event_status.template', '~/mozart/etc/event_status.template', use_jinja=True,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
-        upload_template('sdswatch_client.conf', '~/mozart/etc/sdswatch_client.conf', use_jinja=True,
+        upload_template('sdswatch_client-pcm.conf', '~/mozart/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
     elif node_type == 'metrics':
         upload_template('indexer.conf.metrics', '~/metrics/etc/indexer.conf', use_jinja=True, context=ctx,
@@ -826,10 +826,10 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         upload_template('event_status.template', '~/metrics/etc/event_status.template', use_jinja=True,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
-        upload_template('sdswatch_client.conf', '~/metrics/etc/sdswatch_client.conf', use_jinja=True,
+        upload_template('sdswatch_client-pcm.conf', '~/metrics/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
     elif node_type == 'grq':
-        upload_template('sdswatch_client.conf', '~/sciflo/etc/sdswatch_client.conf', use_jinja=True,
+        upload_template('sdswatch_client-pcm.conf', '~/sciflo/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
     elif node_type in ('verdi', 'verdi-asg', 'factotum'):
         upload_template('sdswatch_client.conf', '~/verdi/etc/sdswatch_client.conf', use_jinja=True,

--- a/sdscli/adapters/hysds/files/run_docker_registry.sh
+++ b/sdscli/adapters/hysds/files/run_docker_registry.sh
@@ -2,7 +2,22 @@
 BASE_PATH=$(dirname "${BASH_SOURCE}")
 BASE_PATH=$(cd "${BASE_PATH}"; pwd)
 
-source $HOME/verdi/bin/activate
+# detect HySDS virtualenv
+if [ -d "${HOME}/mozart" ]; then
+  HYSDS_DIR=${HOME}/mozart
+elif [ -d "${HOME}/metrics" ]; then
+  HYSDS_DIR=${HOME}/metrics
+elif [ -d "${HOME}/sciflo" ]; then
+  HYSDS_DIR=${HOME}/sciflo
+elif [ -d "${HOME}/verdi" ]; then
+  HYSDS_DIR=${HOME}/verdi
+else
+  echo "Couldn't detect installation of HySDS." >&2
+  exit 1
+fi
+
+# source virtualenv
+source $HYSDS_DIR/bin/activate
 
 # Start up Docker Registry if CONTAINER_REGISTRY is defined
 export CONTAINER_REGISTRY="{{ CONTAINER_REGISTRY }}"

--- a/sdscli/adapters/hysds/files/run_sdswatch_client.sh
+++ b/sdscli/adapters/hysds/files/run_sdswatch_client.sh
@@ -40,6 +40,7 @@ else
   echo "Logstash already exists in Docker. Will not download image"
 fi
 exec docker run --rm -e HOST=${FQDN} \
+  -e XPACK_MONITORING_ENABLED=false \
   $verdi_params \
   -v $HYSDS_DIR/log:/sdswatch/log \
   -v sdswatch_data:/usr/share/logstash/data \

--- a/sdscli/adapters/hysds/update.py
+++ b/sdscli/adapters/hysds/update.py
@@ -33,7 +33,7 @@ prompt_style = style_from_dict({
 def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
     """"Update mozart component."""
 
-    num_updates = 29 if config_only else 43  # number of progress bar updates
+    num_updates = 31 if config_only else 45  # number of progress bar updates
 
     with tqdm(total=num_updates) as bar:  # progress bar
         # ensure venv
@@ -119,6 +119,11 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
         execute(fab.send_shipper_conf, 'mozart', '~/mozart/log', conf.get('MOZART_ES_CLUSTER'),
                 '127.0.0.1', conf.get('METRICS_ES_CLUSTER'),
                 conf.get('METRICS_REDIS_PVT_IP'), roles=[comp])
+        bar.update()
+
+        # update HySDS scripts
+        set_bar_desc(bar, 'Updating HySDS scripts')
+        execute(fab.send_hysds_scripts, 'mozart', roles=[comp])
         bar.update()
 
         # update mozart config
@@ -256,6 +261,11 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
                 conf.get('METRICS_REDIS_PVT_IP'), roles=[comp])
         bar.update()
 
+        # update HySDS scripts
+        set_bar_desc(bar, 'Updating HySDS scripts')
+        execute(fab.send_hysds_scripts, 'verdi-asg', roles=[comp])
+        bar.update()
+
         # ship netrc
         netrc = os.path.join(get_user_files_path(), 'netrc')
         if os.path.exists(netrc):
@@ -273,7 +283,7 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
 def update_metrics(conf, ndeps=False, config_only=False, comp='metrics'):
     """"Update metrics component."""
 
-    num_updates = 14 if config_only else 21  # number of progress bar updates
+    num_updates = 15 if config_only else 22  # number of progress bar updates
 
     with tqdm(total=num_updates) as bar:  # progress bar
         # ensure venv
@@ -353,6 +363,11 @@ def update_metrics(conf, ndeps=False, config_only=False, comp='metrics'):
                 '127.0.0.1', roles=[comp])
         bar.update()
 
+        # update HySDS scripts
+        set_bar_desc(bar, 'Updating HySDS scripts')
+        execute(fab.send_hysds_scripts, 'metrics', roles=[comp])
+        bar.update()
+
         # ship kibana config
         set_bar_desc(bar, 'Updating kibana config')
         execute(fab.send_template, 'kibana.yml',
@@ -375,7 +390,7 @@ def update_metrics(conf, ndeps=False, config_only=False, comp='metrics'):
 def update_grq(conf, ndeps=False, config_only=False, comp='grq'):
     """"Update grq component."""
 
-    num_updates = 17 if config_only else 26  # number of progress bar updates
+    num_updates = 18 if config_only else 27  # number of progress bar updates
 
     with tqdm(total=num_updates) as bar:  # progress bar
         # ensure venv
@@ -480,6 +495,11 @@ def update_grq(conf, ndeps=False, config_only=False, comp='grq'):
                 conf.get('METRICS_REDIS_PVT_IP'), roles=[comp])
         bar.update()
 
+        # update HySDS scripts
+        set_bar_desc(bar, 'Updating HySDS scripts')
+        execute(fab.send_hysds_scripts, 'grq', roles=[comp])
+        bar.update()
+
         # ensure self-signed SSL certs exist
         set_bar_desc(bar, 'Configuring SSL')
         execute(fab.ensure_ssl, 'grq', roles=[comp])
@@ -522,7 +542,7 @@ def update_grq(conf, ndeps=False, config_only=False, comp='grq'):
 def update_factotum(conf, ndeps=False, config_only=False, comp='factotum'):
     """"Update factotum component."""
 
-    num_updates = 8 if config_only else 15  # number of progress bar updates
+    num_updates = 9 if config_only else 16  # number of progress bar updates
 
     with tqdm(total=num_updates) as bar:  # progress bar
         # ensure venv
@@ -594,6 +614,11 @@ def update_factotum(conf, ndeps=False, config_only=False, comp='factotum'):
                 conf.get('METRICS_REDIS_PVT_IP'), roles=[comp])
         bar.update()
 
+        # update HySDS scripts
+        set_bar_desc(bar, 'Updating HySDS scripts')
+        execute(fab.send_hysds_scripts, 'factotum', roles=[comp])
+        bar.update()
+
         # expose hysds log dir via webdav
         set_bar_desc(bar, 'Expose logs')
         execute(fab.mkdir, '/data/work', None, None, roles=[comp])
@@ -617,7 +642,7 @@ def update_factotum(conf, ndeps=False, config_only=False, comp='factotum'):
 def update_verdi(conf, ndeps=False, config_only=False, comp='verdi'):
     """"Update verdi component."""
 
-    num_updates = 9 if config_only else 16  # number of progress bar updates
+    num_updates = 10 if config_only else 17  # number of progress bar updates
 
     with tqdm(total=num_updates) as bar:  # progress bar
         # ensure venv
@@ -693,6 +718,11 @@ def update_verdi(conf, ndeps=False, config_only=False, comp='verdi'):
         execute(fab.send_shipper_conf, 'verdi', '~/verdi/log', conf.get('MOZART_ES_CLUSTER'),
                 conf.get('MOZART_REDIS_PVT_IP'), conf.get('METRICS_ES_CLUSTER'),
                 conf.get('METRICS_REDIS_PVT_IP'), roles=[comp])
+        bar.update()
+
+        # update HySDS scripts
+        set_bar_desc(bar, 'Updating HySDS scripts')
+        execute(fab.send_hysds_scripts, 'verdi', roles=[comp])
         bar.update()
 
         # expose hysds log dir via webdav


### PR DESCRIPTION
This PR primarily provisions the mozart, metrics and grq PCM components with the SDSWatch client configuration file (see https://github.com/hysds/hysds/pull/100) and `run_sdswatch_client.sh` script (added to the `send_shipper_conf` fabric function).

Additionally:
- both the `run_sdswatch_client.sh` and `run_docker_registry.sh` scripts have been generalized so that they can run on any of the PCM components: mozart, metrics, grq, factotum, and verdi
- a new fabric function, `send_hysds_scripts`, was added to provision the `run_docker_registry.sh` to the virtualenv bin directory of each component; this function can be extended in the future to provision additional scripts
-  the `run_sdswatch_client.sh` script was updated to disable X-Pack monitoring; otherwise errors trying to reach the license server via Elasticsearch keep accumulating in the log file

See https://hysds-core.atlassian.net/browse/HC-273 for end-to-end test results. 