### PR TITLE
HC-338: initial implementation of OPS UI using SDSWatch and Kibana

### DIFF
--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -817,6 +817,10 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         send_template("run_sdswatch_client.sh", "~/mozart/bin/run_sdswatch_client.sh")
         run("chmod 755 ~/mozart/bin/run_sdswatch_client.sh")
+        send_template("watch_supervisord_services.py", "~/mozart/bin/watch_supervisord_services.py")
+        run("chmod 755 ~/mozart/bin/watch_supervisord_services.py")
+        send_template("watch_systemd_services.py", "~/mozart/bin/watch_systemd_services.py")
+        run("chmod 755 ~/mozart/bin/watch_systemd_services.py")
     elif node_type == 'metrics':
         upload_template('indexer.conf.metrics', '~/metrics/etc/indexer.conf', use_jinja=True, context=ctx,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
@@ -832,16 +836,28 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         send_template("run_sdswatch_client.sh", "~/metrics/bin/run_sdswatch_client.sh")
         run("chmod 755 ~/metrics/bin/run_sdswatch_client.sh")
+        send_template("watch_supervisord_services.py", "~/metrics/bin/watch_supervisord_services.py")
+        run("chmod 755 ~/metrics/bin/watch_supervisord_services.py")
+        send_template("watch_systemd_services.py", "~/metrics/bin/watch_systemd_services.py")
+        run("chmod 755 ~/metrics/bin/watch_systemd_services.py")
     elif node_type == 'grq':
         upload_template('sdswatch_client.conf', '~/sciflo/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         send_template("run_sdswatch_client.sh", "~/sciflo/bin/run_sdswatch_client.sh")
         run("chmod 755 ~/sciflo/bin/run_sdswatch_client.sh")
+        send_template("watch_supervisord_services.py", "~/sciflo/bin/watch_supervisord_services.py")
+        run("chmod 755 ~/sciflo/bin/watch_supervisord_services.py")
+        send_template("watch_systemd_services.py", "~/sciflo/bin/watch_systemd_services.py")
+        run("chmod 755 ~/sciflo/bin/watch_systemd_services.py")
     elif node_type in ('verdi', 'verdi-asg', 'factotum'):
         upload_template('sdswatch_client.conf', '~/verdi/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         send_template("run_sdswatch_client.sh", "~/verdi/bin/run_sdswatch_client.sh")
         run("chmod 755 ~/verdi/bin/run_sdswatch_client.sh")
+        send_template("watch_supervisord_services.py", "~/verdi/bin/watch_supervisord_services.py")
+        run("chmod 755 ~/verdi/bin/watch_supervisord_services.py")
+        send_template("watch_systemd_services.py", "~/verdi/bin/watch_systemd_services.py")
+        run("chmod 755 ~/verdi/bin/watch_systemd_services.py")
     else:
         raise RuntimeError("Unknown node type: %s" % node_type)
 

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -813,7 +813,7 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         upload_template('event_status.template', '~/mozart/etc/event_status.template', use_jinja=True,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
-        upload_template('sdswatch_client-pcm.conf', '~/mozart/etc/sdswatch_client.conf', use_jinja=True,
+        upload_template('sdswatch_client.conf', '~/mozart/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         send_template("run_sdswatch_client.sh", "~/mozart/bin/run_sdswatch_client.sh")
         run("chmod 755 ~/mozart/bin/run_sdswatch_client.sh")
@@ -828,12 +828,12 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         upload_template('event_status.template', '~/metrics/etc/event_status.template', use_jinja=True,
                         template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
-        upload_template('sdswatch_client-pcm.conf', '~/metrics/etc/sdswatch_client.conf', use_jinja=True,
+        upload_template('sdswatch_client.conf', '~/metrics/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         send_template("run_sdswatch_client.sh", "~/metrics/bin/run_sdswatch_client.sh")
         run("chmod 755 ~/metrics/bin/run_sdswatch_client.sh")
     elif node_type == 'grq':
-        upload_template('sdswatch_client-pcm.conf', '~/sciflo/etc/sdswatch_client.conf', use_jinja=True,
+        upload_template('sdswatch_client.conf', '~/sciflo/etc/sdswatch_client.conf', use_jinja=True,
                         context=ctx, template_dir=os.path.join(ops_dir, 'mozart/ops/hysds/configs/logstash'))
         send_template("run_sdswatch_client.sh", "~/sciflo/bin/run_sdswatch_client.sh")
         run("chmod 755 ~/sciflo/bin/run_sdswatch_client.sh")

--- a/sdscli/adapters/hysds/files/kibana_dashboard_import/sdswatch-dashboards-old.json
+++ b/sdscli/adapters/hysds/files/kibana_dashboard_import/sdswatch-dashboards-old.json
@@ -1,0 +1,612 @@
+{
+  "version": "7.1.1",
+  "objects": [
+    {
+      "id": "100e1110-8432-11ea-8f66-23b4730527e4",
+      "type": "dashboard",
+      "updated_at": "2020-09-11T17:03:35.601Z",
+      "version": "WzE0OSw0XQ==",
+      "attributes": {
+        "title": "SDSWatch",
+        "hits": 0,
+        "description": "",
+        "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"h\":9,\"i\":\"1\",\"w\":48,\"x\":0,\"y\":62},\"panelIndex\":\"1\",\"title\":\"Keys over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":6,\"i\":\"9\",\"w\":22,\"x\":0,\"y\":99},\"panelIndex\":\"9\",\"title\":\"Unique Number of Keys\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_1\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":29,\"i\":\"10\",\"w\":48,\"x\":0,\"y\":138},\"panelIndex\":\"10\",\"title\":\"Metrics Table\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_2\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":11,\"i\":\"12\",\"w\":16,\"x\":16,\"y\":127},\"panelIndex\":\"12\",\"title\":\"Avg Value (numeric) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_3\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":11,\"i\":\"13\",\"w\":16,\"x\":0,\"y\":127},\"panelIndex\":\"13\",\"title\":\"Min Value (numeric) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_4\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":11,\"i\":\"14\",\"w\":16,\"x\":32,\"y\":127},\"panelIndex\":\"14\",\"title\":\"Max Value (numeric) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_5\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"15\",\"w\":48,\"x\":0,\"y\":105},\"panelIndex\":\"15\",\"title\":\"Statistics of Values (numeric)\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_6\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":17,\"i\":\"16\",\"w\":22,\"x\":0,\"y\":82},\"panelIndex\":\"16\",\"title\":\"Distribution of Keys\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_7\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":12,\"i\":\"17\",\"w\":20,\"x\":0,\"y\":38},\"panelIndex\":\"17\",\"title\":\"Distribution of Host\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_8\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":12,\"i\":\"18\",\"w\":20,\"x\":0,\"y\":50},\"panelIndex\":\"18\",\"title\":\"Distribution of Source Type\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_9\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":24,\"i\":\"19\",\"w\":28,\"x\":20,\"y\":38},\"panelIndex\":\"19\",\"title\":\"Distribution of Source ID\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_10\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":11,\"i\":\"20\",\"w\":48,\"x\":0,\"y\":71},\"panelIndex\":\"20\",\"title\":\"Value (string) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_11\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":true}},\"gridData\":{\"h\":14,\"i\":\"21\",\"w\":48,\"x\":0,\"y\":113},\"panelIndex\":\"21\",\"title\":\"Avg Value (numeric) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_12\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":17,\"i\":\"22\",\"w\":25,\"x\":22,\"y\":82},\"panelIndex\":\"22\",\"title\":\"Distribution of Values (string)\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_13\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":6,\"i\":\"23\",\"w\":25,\"x\":22,\"y\":99},\"panelIndex\":\"23\",\"title\":\"Unique Number of Values\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_14\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":9,\"i\":\"24\",\"w\":48,\"x\":0,\"y\":0},\"panelIndex\":\"24\",\"title\":\"Host over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_15\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":10,\"i\":\"25\",\"w\":48,\"x\":0,\"y\":9},\"panelIndex\":\"25\",\"title\":\"Source Type over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_16\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":19,\"i\":\"26\",\"w\":48,\"x\":0,\"y\":19},\"panelIndex\":\"26\",\"title\":\"Source ID over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_17\"}]",
+        "optionsJSON": "{\"hidePanelTitles\":false,\"useMargins\":true}",
+        "version": 1,
+        "timeRestore": false,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[]}"
+        }
+      },
+      "references": [
+        {
+          "name": "panel_0",
+          "type": "visualization",
+          "id": "52dba8e0-8432-11ea-8f66-23b4730527e4"
+        },
+        {
+          "name": "panel_1",
+          "type": "visualization",
+          "id": "53de12d0-8434-11ea-8f66-23b4730527e4"
+        },
+        {
+          "name": "panel_2",
+          "type": "search",
+          "id": "2149cfc0-8435-11ea-8f66-23b4730527e4"
+        },
+        {
+          "name": "panel_3",
+          "type": "visualization",
+          "id": "1dc11af0-8766-11ea-a1fc-196a3150a14e"
+        },
+        {
+          "name": "panel_4",
+          "type": "visualization",
+          "id": "3e887500-88e5-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_5",
+          "type": "visualization",
+          "id": "916bf080-88e5-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_6",
+          "type": "visualization",
+          "id": "345318c0-88e9-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_7",
+          "type": "visualization",
+          "id": "82ff6850-88eb-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_8",
+          "type": "visualization",
+          "id": "3c5e0f60-88ef-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_9",
+          "type": "visualization",
+          "id": "e36d3340-88ee-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_10",
+          "type": "visualization",
+          "id": "dfdeee50-88ec-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_11",
+          "type": "visualization",
+          "id": "187e47d0-898b-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_12",
+          "type": "visualization",
+          "id": "4c48e4d0-8986-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_13",
+          "type": "visualization",
+          "id": "07d58710-8998-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_14",
+          "type": "visualization",
+          "id": "2afd9e80-8998-11ea-9fed-5d106481c764"
+        },
+        {
+          "name": "panel_15",
+          "type": "visualization",
+          "id": "c46a8410-964b-11ea-9184-498e3a609b49"
+        },
+        {
+          "name": "panel_16",
+          "type": "visualization",
+          "id": "fad88970-964b-11ea-9184-498e3a609b49"
+        },
+        {
+          "name": "panel_17",
+          "type": "visualization",
+          "id": "2a196650-964c-11ea-9184-498e3a609b49"
+        }
+      ],
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      }
+    },
+    {
+      "id": "52dba8e0-8432-11ea-8f66-23b4730527e4",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "Wzg4LDRd",
+      "attributes": {
+        "title": "Metrics_key over time (SDSWatch)",
+        "visState": "{\"title\":\"Metrics_key over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"2020-04-24T13:37:44.402Z\",\"to\":\"2020-04-25T03:22:22.234Z\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"metric_key.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "53de12d0-8434-11ea-8f66-23b4730527e4",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "Wzg5LDRd",
+      "attributes": {
+        "title": "Unique Number of Metric Key (SDSWatch)",
+        "visState": "{\"title\":\"Unique Number of Metric Key (SDSWatch)\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":60}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_key.keyword\",\"customLabel\":\"Unique Number of Metric Key\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "2149cfc0-8435-11ea-8f66-23b4730527e4",
+      "type": "search",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzkwLDRd",
+      "attributes": {
+        "title": "Metric Table (SDSWatch)",
+        "description": "",
+        "hits": 0,
+        "columns": [
+          "host",
+          "source_type",
+          "source_id",
+          "metric_key",
+          "metric_value_string",
+          "metric_value_float"
+        ],
+        "sort": [
+          "sdswatch_timestamp",
+          "desc"
+        ],
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "search": "7.0.0"
+      }
+    },
+    {
+      "id": "1dc11af0-8766-11ea-a1fc-196a3150a14e",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzkxLDRd",
+      "attributes": {
+        "title": "Average of metric_value_float over time (SDSWatch)",
+        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customMetric\":{\"enabled\":true,\"id\":\"1-metric\",\"params\":{\"field\":\"metric_value_float\"},\"schema\":{\"aggFilter\":[\"!top_hits\",\"!percentiles\",\"!percentile_ranks\",\"!median\",\"!std_dev\",\"!geo_bounds\",\"!geo_centroid\"],\"deprecate\":false,\"editor\":false,\"group\":\"none\",\"hideCustomLabel\":true,\"max\":null,\"min\":0,\"name\":\"metricAgg\",\"params\":[],\"title\":\"Metric Agg\"},\"type\":\"avg\"},\"metricAgg\":\"custom\",\"script\":\"MovingFunctions.unweightedAvg(values)\",\"window\":5},\"schema\":\"metric\",\"type\":\"moving_avg\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"10m\",\"customLabel\":\"\",\"drop_partials\":false,\"extended_bounds\":{},\"field\":\"sdswatch_timestamp\",\"interval\":\"custom\",\"min_doc_count\":0,\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"grid\":{\"categoryLines\":false},\"legendPosition\":\"right\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Moving Avg of Average metric_value_float\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"times\":[],\"type\":\"histogram\",\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Moving Avg of Average metric_value_float\"},\"type\":\"value\"}]},\"title\":\"Average of metric_value_float over time (SDSWatch)\",\"type\":\"histogram\"}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "3e887500-88e5-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzkyLDRd",
+      "attributes": {
+        "title": "Min of metric_value_float over time (SDSWatch)",
+        "visState": "{\"title\":\"Min of metric_value_float over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Min metric_value_float\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Min metric_value_float\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-5h\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "916bf080-88e5-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzkzLDRd",
+      "attributes": {
+        "title": "Max of metric_value_float over time (SDSWatch)",
+        "visState": "{\"title\":\"Max of metric_value_float over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Max metric_value_float\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Max metric_value_float\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-1M\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"15m\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "345318c0-88e9-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "Wzk0LDRd",
+      "attributes": {
+        "title": "Statistics of metric_value_float (SDSWatch)",
+        "visState": "{\"title\":\"Statistics of metric_value_float (SDSWatch)\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"customLabel\":\"Min\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"customLabel\":\"Mean\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"customLabel\":\"Max\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"percents\":[50],\"customLabel\":\"\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"customLabel\":\"Unique Count\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "82ff6850-88eb-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "Wzk1LDRd",
+      "attributes": {
+        "title": "Distribution of Metric Key (SDSWatch)",
+        "visState": "{\"title\":\"Distribution of Metric Key (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"isDonut\":true,\"labels\":{\"show\":true,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"metric_key.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "3c5e0f60-88ef-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "Wzk2LDRd",
+      "attributes": {
+        "title": "Distribution of Host (SDSWatch)",
+        "visState": "{\"title\":\"Distribution of Host (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"isDonut\":true,\"labels\":{\"show\":true,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"host.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "e36d3340-88ee-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "Wzk3LDRd",
+      "attributes": {
+        "title": "Distribution of Source Type (SDSWatch)",
+        "visState": "{\"title\":\"Distribution of Source Type (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"isDonut\":true,\"labels\":{\"show\":true,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"source_type.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "dfdeee50-88ec-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "Wzk4LDRd",
+      "attributes": {
+        "title": "Distribution of Source Id (SDSWatch)",
+        "visState": "{\"title\":\"Distribution of Source Id (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"isDonut\":true,\"labels\":{\"show\":true,\"values\":true,\"last_level\":true,\"truncate\":50}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"source_id.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{\"vis\":{\"legendOpen\":true}}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "187e47d0-898b-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "Wzk5LDRd",
+      "attributes": {
+        "title": "Metric_value_string over time (SDSWatch)",
+        "visState": "{\"title\":\"Metric_value_string over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"2020-04-28T21:14:38.489Z\",\"to\":\"2020-04-28T21:43:16.164Z\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"metric_value_string.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "4c48e4d0-8986-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzEwMCw0XQ==",
+      "attributes": {
+        "title": "Average of metric_value_float over time (per 5 minute) (SDSWatch)",
+        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customMetric\":{\"enabled\":true,\"id\":\"1-metric\",\"params\":{\"field\":\"metric_value_float\"},\"schema\":{\"aggFilter\":[\"!top_hits\",\"!percentiles\",\"!percentile_ranks\",\"!median\",\"!std_dev\",\"!geo_bounds\",\"!geo_centroid\"],\"deprecate\":false,\"editor\":false,\"group\":\"none\",\"hideCustomLabel\":true,\"max\":null,\"min\":0,\"name\":\"metricAgg\",\"params\":[],\"title\":\"Metric Agg\"},\"type\":\"avg\"},\"metricAgg\":\"custom\",\"script\":\"MovingFunctions.unweightedAvg(values)\",\"window\":5},\"schema\":\"metric\",\"type\":\"moving_avg\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"5m\",\"drop_partials\":false,\"extended_bounds\":{},\"field\":\"sdswatch_timestamp\",\"interval\":\"custom\",\"min_doc_count\":0,\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"grid\":{\"categoryLines\":false},\"legendPosition\":\"right\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Moving Avg of Average metric_value_float\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"times\":[],\"type\":\"histogram\",\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Moving Avg of Average metric_value_float\"},\"type\":\"value\"}]},\"title\":\"Average of metric_value_float over time (per 5 minute) (SDSWatch)\",\"type\":\"histogram\"}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "07d58710-8998-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzEwMSw0XQ==",
+      "attributes": {
+        "title": "Distribution of metric_value_string (SDSWatch)",
+        "visState": "{\"title\":\"Distribution of metric_value_string (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"metric_value_string.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "2afd9e80-8998-11ea-9fed-5d106481c764",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzEwMiw0XQ==",
+      "attributes": {
+        "title": "Unique Number of Metric Value String (SDSWatch)",
+        "visState": "{\"title\":\"Unique Number of Metric Value String (SDSWatch)\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":60}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_string.keyword\",\"customLabel\":\"Unique number of Metric Value String\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "c46a8410-964b-11ea-9184-498e3a609b49",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzEwMyw0XQ==",
+      "attributes": {
+        "title": "Host over time (SDSWatch)",
+        "visState": "{\"title\":\"Host over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"host.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "fad88970-964b-11ea-9184-498e3a609b49",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzEwNCw0XQ==",
+      "attributes": {
+        "title": "Source Type over time (SDSWatch)",
+        "visState": "{\"title\":\"Source Type over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"source_type.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "2a196650-964c-11ea-9184-498e3a609b49",
+      "type": "visualization",
+      "updated_at": "2020-09-11T16:42:53.093Z",
+      "version": "WzEwNSw0XQ==",
+      "attributes": {
+        "title": "Source ID over Time",
+        "visState": "{\"title\":\"Source ID over Time\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"source_id.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+        }
+      ],
+      "migrationVersion": {
+        "visualization": "7.0.1"
+      }
+    },
+    {
+      "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4",
+      "type": "index-pattern",
+      "updated_at": "2020-09-11T16:54:17.522Z",
+      "version": "WzE0OCw0XQ==",
+      "attributes": {
+        "title": "sdswatch-*",
+        "timeFieldName": "sdswatch_timestamp",
+        "fields": "[{\"name\":\"@timestamp\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"@version\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"@version.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_score\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_source\",\"type\":\"_source\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"host\",\"type\":\"string\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"host.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"log_path\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"log_path.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"message\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"message.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"metric_key\",\"type\":\"string\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"metric_key.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"metric_value_string\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false,\"count\":3},{\"name\":\"metric_value_string.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"metric_value_float\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"sdswatch_timestamp\",\"type\":\"date\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"source_id\",\"type\":\"string\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"source_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"source_type\",\"type\":\"string\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"source_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]"
+      },
+      "references": [],
+      "migrationVersion": {
+        "index-pattern": "6.5.0"
+      }
+    }
+  ]
+}

--- a/sdscli/adapters/hysds/files/kibana_dashboard_import/sdswatch-dashboards.json
+++ b/sdscli/adapters/hysds/files/kibana_dashboard_import/sdswatch-dashboards.json
@@ -2,15 +2,15 @@
   "version": "7.1.1",
   "objects": [
     {
-      "id": "100e1110-8432-11ea-8f66-23b4730527e4",
+      "id": "482537f0-7d4b-11eb-9963-0336cf2a3b43",
       "type": "dashboard",
-      "updated_at": "2020-09-11T17:03:35.601Z",
-      "version": "WzE0OSw0XQ==",
+      "updated_at": "2021-03-05T02:38:45.481Z",
+      "version": "WzI5LDJd",
       "attributes": {
-        "title": "SDSWatch",
+        "title": "Minimal OPS UI",
         "hits": 0,
-        "description": "",
-        "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"h\":9,\"i\":\"1\",\"w\":48,\"x\":0,\"y\":62},\"panelIndex\":\"1\",\"title\":\"Keys over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":6,\"i\":\"9\",\"w\":22,\"x\":0,\"y\":99},\"panelIndex\":\"9\",\"title\":\"Unique Number of Keys\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_1\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":29,\"i\":\"10\",\"w\":48,\"x\":0,\"y\":138},\"panelIndex\":\"10\",\"title\":\"Metrics Table\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_2\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":11,\"i\":\"12\",\"w\":16,\"x\":16,\"y\":127},\"panelIndex\":\"12\",\"title\":\"Avg Value (numeric) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_3\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":11,\"i\":\"13\",\"w\":16,\"x\":0,\"y\":127},\"panelIndex\":\"13\",\"title\":\"Min Value (numeric) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_4\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":11,\"i\":\"14\",\"w\":16,\"x\":32,\"y\":127},\"panelIndex\":\"14\",\"title\":\"Max Value (numeric) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_5\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"15\",\"w\":48,\"x\":0,\"y\":105},\"panelIndex\":\"15\",\"title\":\"Statistics of Values (numeric)\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_6\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":17,\"i\":\"16\",\"w\":22,\"x\":0,\"y\":82},\"panelIndex\":\"16\",\"title\":\"Distribution of Keys\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_7\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":12,\"i\":\"17\",\"w\":20,\"x\":0,\"y\":38},\"panelIndex\":\"17\",\"title\":\"Distribution of Host\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_8\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":12,\"i\":\"18\",\"w\":20,\"x\":0,\"y\":50},\"panelIndex\":\"18\",\"title\":\"Distribution of Source Type\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_9\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":24,\"i\":\"19\",\"w\":28,\"x\":20,\"y\":38},\"panelIndex\":\"19\",\"title\":\"Distribution of Source ID\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_10\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":11,\"i\":\"20\",\"w\":48,\"x\":0,\"y\":71},\"panelIndex\":\"20\",\"title\":\"Value (string) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_11\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":true}},\"gridData\":{\"h\":14,\"i\":\"21\",\"w\":48,\"x\":0,\"y\":113},\"panelIndex\":\"21\",\"title\":\"Avg Value (numeric) over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_12\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":17,\"i\":\"22\",\"w\":25,\"x\":22,\"y\":82},\"panelIndex\":\"22\",\"title\":\"Distribution of Values (string)\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_13\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":6,\"i\":\"23\",\"w\":25,\"x\":22,\"y\":99},\"panelIndex\":\"23\",\"title\":\"Unique Number of Values\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_14\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":9,\"i\":\"24\",\"w\":48,\"x\":0,\"y\":0},\"panelIndex\":\"24\",\"title\":\"Host over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_15\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":10,\"i\":\"25\",\"w\":48,\"x\":0,\"y\":9},\"panelIndex\":\"25\",\"title\":\"Source Type over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_16\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":19,\"i\":\"26\",\"w\":48,\"x\":0,\"y\":19},\"panelIndex\":\"26\",\"title\":\"Source ID over Time\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_17\"}]",
+        "description": "Minimal example of an OPS UI",
+        "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":0,\"w\":48,\"h\":17,\"i\":\"1\"},\"panelIndex\":\"1\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":17,\"w\":48,\"h\":24,\"i\":\"2\"},\"panelIndex\":\"2\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_1\"}]",
         "optionsJSON": "{\"hidePanelTitles\":false,\"useMargins\":true}",
         "version": 1,
         "timeRestore": false,
@@ -22,92 +22,12 @@
         {
           "name": "panel_0",
           "type": "visualization",
-          "id": "52dba8e0-8432-11ea-8f66-23b4730527e4"
+          "id": "a4ef7320-7d4a-11eb-9963-0336cf2a3b43"
         },
         {
           "name": "panel_1",
           "type": "visualization",
-          "id": "53de12d0-8434-11ea-8f66-23b4730527e4"
-        },
-        {
-          "name": "panel_2",
-          "type": "search",
-          "id": "2149cfc0-8435-11ea-8f66-23b4730527e4"
-        },
-        {
-          "name": "panel_3",
-          "type": "visualization",
-          "id": "1dc11af0-8766-11ea-a1fc-196a3150a14e"
-        },
-        {
-          "name": "panel_4",
-          "type": "visualization",
-          "id": "3e887500-88e5-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_5",
-          "type": "visualization",
-          "id": "916bf080-88e5-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_6",
-          "type": "visualization",
-          "id": "345318c0-88e9-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_7",
-          "type": "visualization",
-          "id": "82ff6850-88eb-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_8",
-          "type": "visualization",
-          "id": "3c5e0f60-88ef-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_9",
-          "type": "visualization",
-          "id": "e36d3340-88ee-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_10",
-          "type": "visualization",
-          "id": "dfdeee50-88ec-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_11",
-          "type": "visualization",
-          "id": "187e47d0-898b-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_12",
-          "type": "visualization",
-          "id": "4c48e4d0-8986-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_13",
-          "type": "visualization",
-          "id": "07d58710-8998-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_14",
-          "type": "visualization",
-          "id": "2afd9e80-8998-11ea-9fed-5d106481c764"
-        },
-        {
-          "name": "panel_15",
-          "type": "visualization",
-          "id": "c46a8410-964b-11ea-9184-498e3a609b49"
-        },
-        {
-          "name": "panel_16",
-          "type": "visualization",
-          "id": "fad88970-964b-11ea-9184-498e3a609b49"
-        },
-        {
-          "name": "panel_17",
-          "type": "visualization",
-          "id": "2a196650-964c-11ea-9184-498e3a609b49"
+          "id": "0ccef100-7d4b-11eb-9963-0336cf2a3b43"
         }
       ],
       "migrationVersion": {
@@ -115,25 +35,26 @@
       }
     },
     {
-      "id": "52dba8e0-8432-11ea-8f66-23b4730527e4",
+      "id": "a4ef7320-7d4a-11eb-9963-0336cf2a3b43",
       "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "Wzg4LDRd",
+      "updated_at": "2021-03-05T02:36:01.512Z",
+      "version": "WzI3LDJd",
       "attributes": {
-        "title": "Metrics_key over time (SDSWatch)",
-        "visState": "{\"title\":\"Metrics_key over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"2020-04-24T13:37:44.402Z\",\"to\":\"2020-04-25T03:22:22.234Z\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"metric_key.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{}",
+        "title": "Systemd Service Status",
+        "visState": "{\"title\":\"Systemd Service Status\",\"type\":\"table\",\"params\":{\"perPage\":100,\"showPartialRows\":false,\"showMetricsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"sdswatch_timestamp\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"systemd.ActiveState.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"systemd.SubState.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"systemd.ActiveStateTimestamp.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"host.keyword\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"_key\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"systemd.service.keyword\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"_key\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
         "description": "",
         "version": 1,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
+          "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
       },
       "references": [
         {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+          "name": "search_0",
+          "type": "search",
+          "id": "2089dd50-7d4a-11eb-9963-0336cf2a3b43"
         }
       ],
       "migrationVersion": {
@@ -141,25 +62,26 @@
       }
     },
     {
-      "id": "53de12d0-8434-11ea-8f66-23b4730527e4",
+      "id": "0ccef100-7d4b-11eb-9963-0336cf2a3b43",
       "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "Wzg5LDRd",
+      "updated_at": "2021-03-05T00:49:38.329Z",
+      "version": "WzIzLDJd",
       "attributes": {
-        "title": "Unique Number of Metric Key (SDSWatch)",
-        "visState": "{\"title\":\"Unique Number of Metric Key (SDSWatch)\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":60}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_key.keyword\",\"customLabel\":\"Unique Number of Metric Key\"}}]}",
-        "uiStateJSON": "{}",
+        "title": "Supervisord Service Status",
+        "visState": "{\"title\":\"Supervisord Service Status\",\"type\":\"table\",\"params\":{\"perPage\":100,\"showPartialRows\":false,\"showMetricsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"sdswatch_timestamp\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"host.keyword\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"_key\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"supervisord.service.keyword\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"_key\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"supervisord.status.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"supervisord.uptime.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"@timestamp\",\"sortOrder\":\"desc\"}}]}",
+        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
         "description": "",
         "version": 1,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
       },
       "references": [
         {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+          "name": "search_0",
+          "type": "search",
+          "id": "2ea8d300-7d4a-11eb-9963-0336cf2a3b43"
         }
       ],
       "migrationVersion": {
@@ -167,36 +89,36 @@
       }
     },
     {
-      "id": "2149cfc0-8435-11ea-8f66-23b4730527e4",
+      "id": "2089dd50-7d4a-11eb-9963-0336cf2a3b43",
       "type": "search",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzkwLDRd",
+      "updated_at": "2021-03-05T00:31:29.189Z",
+      "version": "WzEzLDJd",
       "attributes": {
-        "title": "Metric Table (SDSWatch)",
+        "title": "Search: systemd",
         "description": "",
         "hits": 0,
         "columns": [
-          "host",
-          "source_type",
-          "source_id",
-          "metric_key",
-          "metric_value_string",
-          "metric_value_float"
+          "_source"
         ],
         "sort": [
-          "sdswatch_timestamp",
+          "@timestamp",
           "desc"
         ],
         "version": 1,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+          "searchSourceJSON": "{\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[{\"meta\":{\"negate\":false,\"type\":\"phrase\",\"key\":\"source_type\",\"value\":\"systemd\",\"params\":{\"query\":\"systemd\"},\"disabled\":false,\"alias\":null,\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index\"},\"query\":{\"match\":{\"source_type\":{\"query\":\"systemd\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
         }
       },
       "references": [
         {
           "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
           "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+          "id": "684cf7c0-7d37-11eb-9ca4-d9758905c91a"
+        },
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+          "type": "index-pattern",
+          "id": "684cf7c0-7d37-11eb-9ca4-d9758905c91a"
         }
       ],
       "migrationVersion": {
@@ -204,404 +126,51 @@
       }
     },
     {
-      "id": "1dc11af0-8766-11ea-a1fc-196a3150a14e",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzkxLDRd",
+      "id": "2ea8d300-7d4a-11eb-9963-0336cf2a3b43",
+      "type": "search",
+      "updated_at": "2021-03-05T00:31:52.880Z",
+      "version": "WzE0LDJd",
       "attributes": {
-        "title": "Average of metric_value_float over time (SDSWatch)",
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customMetric\":{\"enabled\":true,\"id\":\"1-metric\",\"params\":{\"field\":\"metric_value_float\"},\"schema\":{\"aggFilter\":[\"!top_hits\",\"!percentiles\",\"!percentile_ranks\",\"!median\",\"!std_dev\",\"!geo_bounds\",\"!geo_centroid\"],\"deprecate\":false,\"editor\":false,\"group\":\"none\",\"hideCustomLabel\":true,\"max\":null,\"min\":0,\"name\":\"metricAgg\",\"params\":[],\"title\":\"Metric Agg\"},\"type\":\"avg\"},\"metricAgg\":\"custom\",\"script\":\"MovingFunctions.unweightedAvg(values)\",\"window\":5},\"schema\":\"metric\",\"type\":\"moving_avg\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"10m\",\"customLabel\":\"\",\"drop_partials\":false,\"extended_bounds\":{},\"field\":\"sdswatch_timestamp\",\"interval\":\"custom\",\"min_doc_count\":0,\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"grid\":{\"categoryLines\":false},\"legendPosition\":\"right\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Moving Avg of Average metric_value_float\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"times\":[],\"type\":\"histogram\",\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Moving Avg of Average metric_value_float\"},\"type\":\"value\"}]},\"title\":\"Average of metric_value_float over time (SDSWatch)\",\"type\":\"histogram\"}",
-        "uiStateJSON": "{}",
+        "title": "Search: supervisord",
         "description": "",
+        "hits": 0,
+        "columns": [
+          "_source"
+        ],
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
         "version": 1,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+          "searchSourceJSON": "{\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[{\"meta\":{\"negate\":false,\"type\":\"phrase\",\"key\":\"source_type\",\"value\":\"supervisord\",\"params\":{\"query\":\"supervisord\"},\"disabled\":false,\"alias\":null,\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index\"},\"query\":{\"match\":{\"source_type\":{\"query\":\"supervisord\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
         }
       },
       "references": [
         {
           "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
           "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "3e887500-88e5-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzkyLDRd",
-      "attributes": {
-        "title": "Min of metric_value_float over time (SDSWatch)",
-        "visState": "{\"title\":\"Min of metric_value_float over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Min metric_value_float\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Min metric_value_float\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-5h\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
+          "id": "684cf7c0-7d37-11eb-9ca4-d9758905c91a"
+        },
         {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
           "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
+          "id": "684cf7c0-7d37-11eb-9ca4-d9758905c91a"
         }
       ],
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "search": "7.0.0"
       }
     },
     {
-      "id": "916bf080-88e5-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzkzLDRd",
-      "attributes": {
-        "title": "Max of metric_value_float over time (SDSWatch)",
-        "visState": "{\"title\":\"Max of metric_value_float over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Max metric_value_float\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Max metric_value_float\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-1M\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"15m\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "345318c0-88e9-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "Wzk0LDRd",
-      "attributes": {
-        "title": "Statistics of metric_value_float (SDSWatch)",
-        "visState": "{\"title\":\"Statistics of metric_value_float (SDSWatch)\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"customLabel\":\"Min\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"customLabel\":\"Mean\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"customLabel\":\"Max\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"percents\":[50],\"customLabel\":\"\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_float\",\"customLabel\":\"Unique Count\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "82ff6850-88eb-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "Wzk1LDRd",
-      "attributes": {
-        "title": "Distribution of Metric Key (SDSWatch)",
-        "visState": "{\"title\":\"Distribution of Metric Key (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"isDonut\":true,\"labels\":{\"show\":true,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"metric_key.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "3c5e0f60-88ef-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "Wzk2LDRd",
-      "attributes": {
-        "title": "Distribution of Host (SDSWatch)",
-        "visState": "{\"title\":\"Distribution of Host (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"isDonut\":true,\"labels\":{\"show\":true,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"host.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "e36d3340-88ee-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "Wzk3LDRd",
-      "attributes": {
-        "title": "Distribution of Source Type (SDSWatch)",
-        "visState": "{\"title\":\"Distribution of Source Type (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"isDonut\":true,\"labels\":{\"show\":true,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"source_type.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "dfdeee50-88ec-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "Wzk4LDRd",
-      "attributes": {
-        "title": "Distribution of Source Id (SDSWatch)",
-        "visState": "{\"title\":\"Distribution of Source Id (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"isDonut\":true,\"labels\":{\"show\":true,\"values\":true,\"last_level\":true,\"truncate\":50}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"source_id.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{\"vis\":{\"legendOpen\":true}}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "187e47d0-898b-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "Wzk5LDRd",
-      "attributes": {
-        "title": "Metric_value_string over time (SDSWatch)",
-        "visState": "{\"title\":\"Metric_value_string over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"2020-04-28T21:14:38.489Z\",\"to\":\"2020-04-28T21:43:16.164Z\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"metric_value_string.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "4c48e4d0-8986-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzEwMCw0XQ==",
-      "attributes": {
-        "title": "Average of metric_value_float over time (per 5 minute) (SDSWatch)",
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customMetric\":{\"enabled\":true,\"id\":\"1-metric\",\"params\":{\"field\":\"metric_value_float\"},\"schema\":{\"aggFilter\":[\"!top_hits\",\"!percentiles\",\"!percentile_ranks\",\"!median\",\"!std_dev\",\"!geo_bounds\",\"!geo_centroid\"],\"deprecate\":false,\"editor\":false,\"group\":\"none\",\"hideCustomLabel\":true,\"max\":null,\"min\":0,\"name\":\"metricAgg\",\"params\":[],\"title\":\"Metric Agg\"},\"type\":\"avg\"},\"metricAgg\":\"custom\",\"script\":\"MovingFunctions.unweightedAvg(values)\",\"window\":5},\"schema\":\"metric\",\"type\":\"moving_avg\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"5m\",\"drop_partials\":false,\"extended_bounds\":{},\"field\":\"sdswatch_timestamp\",\"interval\":\"custom\",\"min_doc_count\":0,\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"grid\":{\"categoryLines\":false},\"legendPosition\":\"right\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Moving Avg of Average metric_value_float\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"times\":[],\"type\":\"histogram\",\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Moving Avg of Average metric_value_float\"},\"type\":\"value\"}]},\"title\":\"Average of metric_value_float over time (per 5 minute) (SDSWatch)\",\"type\":\"histogram\"}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "07d58710-8998-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzEwMSw0XQ==",
-      "attributes": {
-        "title": "Distribution of metric_value_string (SDSWatch)",
-        "visState": "{\"title\":\"Distribution of metric_value_string (SDSWatch)\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"metric_value_string.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "2afd9e80-8998-11ea-9fed-5d106481c764",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzEwMiw0XQ==",
-      "attributes": {
-        "title": "Unique Number of Metric Value String (SDSWatch)",
-        "visState": "{\"title\":\"Unique Number of Metric Value String (SDSWatch)\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":60}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"metric_value_string.keyword\",\"customLabel\":\"Unique number of Metric Value String\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "c46a8410-964b-11ea-9184-498e3a609b49",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzEwMyw0XQ==",
-      "attributes": {
-        "title": "Host over time (SDSWatch)",
-        "visState": "{\"title\":\"Host over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"host.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "fad88970-964b-11ea-9184-498e3a609b49",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzEwNCw0XQ==",
-      "attributes": {
-        "title": "Source Type over time (SDSWatch)",
-        "visState": "{\"title\":\"Source Type over time (SDSWatch)\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"source_type.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "2a196650-964c-11ea-9184-498e3a609b49",
-      "type": "visualization",
-      "updated_at": "2020-09-11T16:42:53.093Z",
-      "version": "WzEwNSw0XQ==",
-      "attributes": {
-        "title": "Source ID over Time",
-        "visState": "{\"title\":\"Source ID over Time\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"sdswatch_timestamp\",\"timeRange\":{\"from\":\"now-2d\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"interval\":\"custom\",\"drop_partials\":false,\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"source_id.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
-        "uiStateJSON": "{}",
-        "description": "",
-        "version": 1,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
-        }
-      },
-      "references": [
-        {
-          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-          "type": "index-pattern",
-          "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4"
-        }
-      ],
-      "migrationVersion": {
-        "visualization": "7.0.1"
-      }
-    },
-    {
-      "id": "ffc7f5a0-8431-11ea-8f66-23b4730527e4",
+      "id": "684cf7c0-7d37-11eb-9ca4-d9758905c91a",
       "type": "index-pattern",
-      "updated_at": "2020-09-11T16:54:17.522Z",
-      "version": "WzE0OCw0XQ==",
+      "updated_at": "2021-03-05T00:30:59.254Z",
+      "version": "WzEyLDJd",
       "attributes": {
         "title": "sdswatch-*",
-        "timeFieldName": "sdswatch_timestamp",
-        "fields": "[{\"name\":\"@timestamp\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"@version\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"@version.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_score\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_source\",\"type\":\"_source\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"host\",\"type\":\"string\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"host.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"log_path\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"log_path.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"message\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"message.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"metric_key\",\"type\":\"string\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"metric_key.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"metric_value_string\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false,\"count\":3},{\"name\":\"metric_value_string.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"metric_value_float\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"sdswatch_timestamp\",\"type\":\"date\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"source_id\",\"type\":\"string\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"source_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"source_type\",\"type\":\"string\",\"count\":2,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"source_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]"
+        "timeFieldName": "@timestamp",
+        "fields": "[{\"name\":\"@index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"@index.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"@timestamp\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"@version\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_score\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_source\",\"type\":\"_source\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"host\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"host.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"log_path\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"log_path.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"message\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"message.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"sdswatch_timestamp\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"source_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"source_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"source_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"source_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"supervisord.pid\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"supervisord.service\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"supervisord.service.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"supervisord.status\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"supervisord.status.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"supervisord.uptime\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"supervisord.uptime.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"systemd.ActiveState\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"systemd.ActiveState.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"systemd.ActiveStateTimestamp\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"systemd.ActiveStateTimestamp.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"systemd.SubState\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"systemd.SubState.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"systemd.WatchdogTimestamp\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"systemd.WatchdogTimestamp.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"systemd.service\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"systemd.service.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]"
       },
       "references": [],
       "migrationVersion": {

--- a/sdscli/adapters/hysds/files/watch_supervisord_services.py
+++ b/sdscli/adapters/hysds/files/watch_supervisord_services.py
@@ -16,9 +16,10 @@ RUNNING_RE = re.compile(r'^(?P<service>.+?)\s+(?P<status>RUNNING)\s+pid\s+(?P<pi
 STOPPED_RE = re.compile(r'^(?P<service>.+?)\s+(?P<status>STOPPED)\s+(?P<date_stopped>.+)$')
 
 
-def daemon(check, name, source_type, source_id, services):
+def daemon(check, host, name, source_type, source_id, services):
     print("configuration:")
     print(f"check: {check}")
+    print(f"host: {host}")
     print(f"name: {name}")
     print(f"source_type: {source_type}")
     print(f"source_id: {source_id}")
@@ -44,10 +45,10 @@ def daemon(check, name, source_type, source_id, services):
         for line in lines:
             if m := RUNNING_RE.search(line):
                 g = m.groupdict() 
-                print(f'{timestamp}, nisar-mozart.jpl.nasa.gov, supervisord, status, supervisord.service={g["service"]} supervisord.status={g["status"]} supervisord.pid={g["pid"]} supervisord.uptime="{g["uptime"]}"', flush=True)
+                print(f'{timestamp}, {host}, supervisord, status, supervisord.service={g["service"]} supervisord.status={g["status"]} supervisord.pid={g["pid"]} supervisord.uptime="{g["uptime"]}"', flush=True)
             elif m:= STOPPED_RE.search(line):
                 g = m.groupdict() 
-                print(f'{timestamp}, nisar-mozart.jpl.nasa.gov, supervisord, status, supervisord.service={g["service"]} supervisord.status={g["status"]} supervisord.date_stopped="{g["date_stopped"]}"', flush=True)
+                print(f'{timestamp}, {host}, supervisord, status, supervisord.service={g["service"]} supervisord.status={g["status"]} supervisord.date_stopped="{g["date_stopped"]}"', flush=True)
         time.sleep(check)
 
 
@@ -59,6 +60,12 @@ if __name__ == "__main__":
         type=int,
         default=60,
         help="check and dump logs every N seconds. Default is 60.",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        required=True,
+        help="Host name.",
     )
     parser.add_argument(
         "-n",
@@ -91,4 +98,4 @@ if __name__ == "__main__":
         help="Systemd services to check.",
     )
     args = parser.parse_args()
-    daemon(args.check, args.name, args.source_type, args.source_id, args.services)
+    daemon(args.check, args.host, args.name, args.source_type, args.source_id, args.services)

--- a/sdscli/adapters/hysds/files/watch_supervisord_services.py
+++ b/sdscli/adapters/hysds/files/watch_supervisord_services.py
@@ -16,9 +16,8 @@ RUNNING_RE = re.compile(r'^(?P<service>.+?)\s+(?P<status>RUNNING)\s+pid\s+(?P<pi
 STOPPED_RE = re.compile(r'^(?P<service>.+?)\s+(?P<status>STOPPED)\s+(?P<date_stopped>.+)$')
 
 
-def daemon(file_dir, check, name, source_type, source_id, services):
+def daemon(check, name, source_type, source_id, services):
     print("configuration:")
-    print(f"file_dir: {file_dir}")
     print(f"check: {check}")
     print(f"name: {name}")
     print(f"source_type: {source_type}")
@@ -54,13 +53,6 @@ def daemon(file_dir, check, name, source_type, source_id, services):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "-d",
-        "--file_dir",
-        type=str,
-        required=True,
-        help="log directory, e.g. /home/ops/mozart/log",
-    )
     parser.add_argument(
         "-c",
         "--check",
@@ -99,4 +91,4 @@ if __name__ == "__main__":
         help="Systemd services to check.",
     )
     args = parser.parse_args()
-    daemon(args.file_dir, args.check, args.name, args.source_type, args.source_id, args.services)
+    daemon(args.check, args.name, args.source_type, args.source_id, args.services)

--- a/sdscli/adapters/hysds/files/watch_supervisord_services.py
+++ b/sdscli/adapters/hysds/files/watch_supervisord_services.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""
+SDSWatch daemon to periodically dump SDSWatch logs of supervisord services.
+"""
+import os
+import argparse
+import time
+import re
+import backoff
+from subprocess import check_output, STDOUT, CalledProcessError
+from datetime import datetime
+
+
+# regexes
+RUNNING_RE = re.compile(r'^(?P<service>.+?)\s+(?P<status>RUNNING)\s+pid\s+(?P<pid>\d+),\s+uptime\s+(?P<uptime>.+)$')
+STOPPED_RE = re.compile(r'^(?P<service>.+?)\s+(?P<status>STOPPED)\s+(?P<date_stopped>.+)$')
+
+
+def daemon(file_dir, check, name, source_type, source_id, services):
+    print("configuration:")
+    print(f"file_dir: {file_dir}")
+    print(f"check: {check}")
+    print(f"name: {name}")
+    print(f"source_type: {source_type}")
+    print(f"source_id: {source_id}")
+    print(f"services: {services}")
+
+    while True:
+        if services is None:
+            try:
+                output = check_output(["supervisorctl", "status"], universal_newlines=True)
+            except Exception as e:
+                output = str(e.output)
+            #print(output)
+            lines = [i.strip() for i in output.split('\n')]
+        else:
+            lines = []
+            for service in services:
+                try:
+                    output = check_output(["supervisorctl", "status", service], universal_newlines=True)
+                except Exception as e:
+                    output = str(e.output)
+                lines.extend([i.strip() for i in output.split('\n')])
+        timestamp = datetime.utcnow().isoformat()
+        for line in lines:
+            if m := RUNNING_RE.search(line):
+                g = m.groupdict() 
+                print(f'{timestamp}, nisar-mozart.jpl.nasa.gov, supervisord, status, supervisord.service={g["service"]} supervisord.status={g["status"]} supervisord.pid={g["pid"]} supervisord.uptime="{g["uptime"]}"', flush=True)
+            elif m:= STOPPED_RE.search(line):
+                g = m.groupdict() 
+                print(f'{timestamp}, nisar-mozart.jpl.nasa.gov, supervisord, status, supervisord.service={g["service"]} supervisord.status={g["status"]} supervisord.date_stopped="{g["date_stopped"]}"', flush=True)
+        time.sleep(check)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-d",
+        "--file_dir",
+        type=str,
+        required=True,
+        help="log directory, e.g. /home/ops/mozart/log",
+    )
+    parser.add_argument(
+        "-c",
+        "--check",
+        type=int,
+        default=60,
+        help="check and dump logs every N seconds. Default is 60.",
+    )
+    parser.add_argument(
+        "-n",
+        "--name",
+        type=str,
+        default="systemd",
+        help="Log file basename. Defaults to 'supervisord'.",
+    )
+    parser.add_argument(
+        "-t",
+        "--source_type",
+        type=str,
+        default="unspecified",
+        help="Source type. Defaults to 'unspecified'.",
+    )
+    parser.add_argument(
+        "-i",
+        "--source_id",
+        type=str,
+        default="systemd",
+        help="Source type. Defaults to 'supervisord'.",
+    )
+    parser.add_argument(
+        "-s",
+        "--services",
+        nargs="+",
+        required=False,
+        type=str,
+        default=None,
+        help="Systemd services to check.",
+    )
+    args = parser.parse_args()
+    daemon(args.file_dir, args.check, args.name, args.source_type, args.source_id, args.services)

--- a/sdscli/adapters/hysds/files/watch_systemd_services.py
+++ b/sdscli/adapters/hysds/files/watch_systemd_services.py
@@ -18,9 +18,8 @@ ACTIVEENTER_TS_RE = re.compile(r'\nActiveEnterTimestamp=(?P<ActiveEnterTimestamp
 WATCHDOG_TS_RE = re.compile(r'\nWatchdogTimestamp=(?P<WatchdogTimestamp>.+)\n')
 
 
-def daemon(file_dir, check, name, source_type, source_id, services):
+def daemon(check, name, source_type, source_id, services):
     print("configuration:")
-    print(f"file_dir: {file_dir}")
     print(f"check: {check}")
     print(f"name: {name}")
     print(f"source_type: {source_type}")
@@ -49,13 +48,6 @@ def daemon(file_dir, check, name, source_type, source_id, services):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "-d",
-        "--file_dir",
-        type=str,
-        required=True,
-        help="log directory, e.g. /home/ops/mozart/log",
-    )
     parser.add_argument(
         "-c",
         "--check",
@@ -93,4 +85,4 @@ if __name__ == "__main__":
         help="Systemd services to check.",
     )
     args = parser.parse_args()
-    daemon(args.file_dir, args.check, args.name, args.source_type, args.source_id, args.services)
+    daemon(args.check, args.name, args.source_type, args.source_id, args.services)

--- a/sdscli/adapters/hysds/files/watch_systemd_services.py
+++ b/sdscli/adapters/hysds/files/watch_systemd_services.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""
+SDSWatch daemon to periodically dump SDSWatch logs of systemd services.
+"""
+import os
+import argparse
+import time
+import re
+import backoff
+from subprocess import check_output, STDOUT, CalledProcessError
+from datetime import datetime
+
+
+# regexes
+ACTIVESTATE_RE = re.compile(r'\nActiveState=(?P<ActiveState>.+)\n')
+SUBSTATE_RE = re.compile(r'\nSubState=(?P<SubState>.+)\n')
+ACTIVEENTER_TS_RE = re.compile(r'\nActiveEnterTimestamp=(?P<ActiveEnterTimestamp>.+)\n')
+WATCHDOG_TS_RE = re.compile(r'\nWatchdogTimestamp=(?P<WatchdogTimestamp>.+)\n')
+
+
+def daemon(file_dir, check, name, source_type, source_id, services):
+    print("configuration:")
+    print(f"file_dir: {file_dir}")
+    print(f"check: {check}")
+    print(f"name: {name}")
+    print(f"source_type: {source_type}")
+    print(f"source_id: {source_id}")
+    print(f"services: {services}")
+
+    while True:
+        for service in services:
+            output = check_output(["sudo", "systemctl", "show", "--no-page", service], universal_newlines=True)
+            #print("#" * 80)
+            #print(f"{service}")
+            #print(output)
+            if m := ACTIVESTATE_RE.search(output):
+                active_state = m.group(1)
+            if m := SUBSTATE_RE.search(output):
+                sub_state = m.group(1)
+            if m := ACTIVEENTER_TS_RE.search(output):
+                active_enter_ts = m.group(1)
+            if m:= WATCHDOG_TS_RE.search(output):
+                watchdog_ts = m.group(1)
+            timestamp = datetime.utcnow().isoformat()
+            print(f'{timestamp}, nisar-mozart.jpl.nasa.gov, systemd, status, systemd.service={service} systemd.ActiveState={active_state} systemd.SubState={sub_state} systemd.ActiveStateTimestamp="{active_enter_ts}" systemd.WatchdogTimestamp="{watchdog_ts}"', flush=True)
+             
+        time.sleep(check)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-d",
+        "--file_dir",
+        type=str,
+        required=True,
+        help="log directory, e.g. /home/ops/mozart/log",
+    )
+    parser.add_argument(
+        "-c",
+        "--check",
+        type=int,
+        default=60,
+        help="check and dump logs every N seconds. Default is 60.",
+    )
+    parser.add_argument(
+        "-n",
+        "--name",
+        type=str,
+        default="systemd",
+        help="Log file basename. Defaults to 'systemd'.",
+    )
+    parser.add_argument(
+        "-t",
+        "--source_type",
+        type=str,
+        default="unspecified",
+        help="Source type. Defaults to 'unspecified'.",
+    )
+    parser.add_argument(
+        "-i",
+        "--source_id",
+        type=str,
+        default="systemd",
+        help="Source type. Defaults to 'systemd'.",
+    )
+    parser.add_argument(
+        "-s",
+        "--services",
+        nargs="+",
+        required=True,
+        type=str,
+        help="Systemd services to check.",
+    )
+    args = parser.parse_args()
+    daemon(args.file_dir, args.check, args.name, args.source_type, args.source_id, args.services)

--- a/sdscli/adapters/hysds/files/watch_systemd_services.py
+++ b/sdscli/adapters/hysds/files/watch_systemd_services.py
@@ -18,9 +18,10 @@ ACTIVEENTER_TS_RE = re.compile(r'\nActiveEnterTimestamp=(?P<ActiveEnterTimestamp
 WATCHDOG_TS_RE = re.compile(r'\nWatchdogTimestamp=(?P<WatchdogTimestamp>.+)\n')
 
 
-def daemon(check, name, source_type, source_id, services):
+def daemon(check, host, name, source_type, source_id, services):
     print("configuration:")
     print(f"check: {check}")
+    print(f"host: {host}")
     print(f"name: {name}")
     print(f"source_type: {source_type}")
     print(f"source_id: {source_id}")
@@ -41,7 +42,7 @@ def daemon(check, name, source_type, source_id, services):
             if m:= WATCHDOG_TS_RE.search(output):
                 watchdog_ts = m.group(1)
             timestamp = datetime.utcnow().isoformat()
-            print(f'{timestamp}, nisar-mozart.jpl.nasa.gov, systemd, status, systemd.service={service} systemd.ActiveState={active_state} systemd.SubState={sub_state} systemd.ActiveStateTimestamp="{active_enter_ts}" systemd.WatchdogTimestamp="{watchdog_ts}"', flush=True)
+            print(f'{timestamp}, {host}, systemd, status, systemd.service={service} systemd.ActiveState={active_state} systemd.SubState={sub_state} systemd.ActiveStateTimestamp="{active_enter_ts}" systemd.WatchdogTimestamp="{watchdog_ts}"', flush=True)
              
         time.sleep(check)
 
@@ -54,6 +55,12 @@ if __name__ == "__main__":
         type=int,
         default=60,
         help="check and dump logs every N seconds. Default is 60.",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        required=True,
+        help="Host name.",
     )
     parser.add_argument(
         "-n",
@@ -85,4 +92,4 @@ if __name__ == "__main__":
         help="Systemd services to check.",
     )
     args = parser.parse_args()
-    daemon(args.check, args.name, args.source_type, args.source_id, args.services)
+    daemon(args.check, args.host, args.name, args.source_type, args.source_id, args.services)


### PR DESCRIPTION
This PR exists is in conjunction with https://github.com/hysds/hysds/pull/103 and:
- updates the provisioning of the consolidated SDSWatch logstash configuration file
- adds and provisions the SDSWatch loggers for `systemd` and `supervisord` services
- updates the `sdswatch-dashboards.json` Kibana export with a minimal OPS UI