### PR TITLE
Hc 348 - customizable tosca/figaro config in hysds_ui

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -252,6 +252,14 @@ def send_template(tmpl, dest, tmpl_dir=None, node_type=None):
 
 
 def send_template_user_override(tmpl, dest, tmpl_dir=None, node_type=None):
+    """
+
+    :param tmpl:
+    :param dest:
+    :param tmpl_dir:
+    :param node_type:
+    :return:
+    """
     if tmpl_dir is None:
         tmpl_dir = get_user_files_path()
     else:
@@ -917,11 +925,18 @@ def send_hysds_ui_conf():
     upload_template('index.template.js', dest_file, use_jinja=True, context=get_context('mozart'),
                     template_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'))
 
+    tosca_cfg = '~/mozart/etc/tosca.js'
+    send_template_user_override('tosca.template.js', tosca_cfg,
+                                tmpl_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'),
+                                node_type='mozart')
+    figaro_cfg = '~/mozart/etc/figaro.js'
+    send_template_user_override('figaro.template.js', figaro_cfg,
+                                tmpl_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'),
+                                node_type='mozart')
 
-def send_hysds_ui_conf():
-    dest_file = '~/mozart/ops/hysds_ui/src/config/index.js'
-    upload_template('index.template.js', dest_file, use_jinja=True, context=get_context('mozart'),
-                    template_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'))
+    # symlink all to ~/mozart/ops/hysds_ui/src/config/
+    ln_sf(tosca_cfg, os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config', 'tosca.js'))
+    ln_sf(figaro_cfg, os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config', 'figaro.js'))
 
 
 def send_grq2conf():

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -925,16 +925,27 @@ def send_hysds_ui_conf():
     upload_template('index.template.js', dest_file, use_jinja=True, context=get_context('mozart'),
                     template_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'))
 
-    tosca_cfg = '~/mozart/etc/tosca.js'
-    send_template_user_override('tosca.template.js', tosca_cfg,
-                                tmpl_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'),
-                                node_type='mozart')
-    figaro_cfg = '~/mozart/etc/figaro.js'
-    send_template_user_override('figaro.template.js', figaro_cfg,
-                                tmpl_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'),
-                                node_type='mozart')
+    user_path = get_user_files_path()
 
-    # symlink all to ~/mozart/ops/hysds_ui/src/config/
+    tosca_cfg = '~/mozart/etc/tosca.js'
+    if os.path.exists(os.path.join(user_path, 'tosca.js')):
+        send_template_user_override('tosca.js', tosca_cfg, node_type='mozart')
+    else:
+        send_template_user_override('tosca.template.js', tosca_cfg,
+                                    tmpl_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'),
+                                    node_type='mozart')
+
+    figaro_cfg = '~/mozart/etc/figaro.js'
+    if os.path.exists(os.path.join(user_path, 'figaro.js')):
+        print('using custom figaro.js')
+        send_template_user_override('figaro.js', figaro_cfg, node_type='mozart')
+    else:
+        print('usinng default figaro.js')
+        send_template_user_override('figaro.template.js', figaro_cfg,
+                                    tmpl_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'),
+                                    node_type='mozart')
+
+    # symlink to ~/mozart/ops/hysds_ui/src/config/
     ln_sf(tosca_cfg, os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config', 'tosca.js'))
     ln_sf(figaro_cfg, os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config', 'figaro.js'))
 

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -929,18 +929,20 @@ def send_hysds_ui_conf():
 
     tosca_cfg = '~/mozart/etc/tosca.js'
     if os.path.exists(os.path.join(user_path, 'tosca.js')):
+        print('using custom tosca configuration in .sds/files')
         send_template_user_override('tosca.js', tosca_cfg, node_type='mozart')
     else:
+        print('using default tosca configuration')
         send_template_user_override('tosca.template.js', tosca_cfg,
                                     tmpl_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'),
                                     node_type='mozart')
 
     figaro_cfg = '~/mozart/etc/figaro.js'
     if os.path.exists(os.path.join(user_path, 'figaro.js')):
-        print('using custom figaro.js')
+        print('using custom figaro configuration in .sds/files')
         send_template_user_override('figaro.js', figaro_cfg, node_type='mozart')
     else:
-        print('usinng default figaro.js')
+        print('using default figaro configuration')
         send_template_user_override('figaro.template.js', figaro_cfg,
                                     tmpl_dir=os.path.join(ops_dir, 'mozart/ops/hysds_ui/src/config'),
                                     node_type='mozart')

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -253,12 +253,13 @@ def send_template(tmpl, dest, tmpl_dir=None, node_type=None):
 
 def send_template_user_override(tmpl, dest, tmpl_dir=None, node_type=None):
     """
-
-    :param tmpl:
-    :param dest:
-    :param tmpl_dir:
-    :param node_type:
-    :return:
+    Write filled-out template to destination using the template found in a specified template directory.
+    If template exists in the user files (i.e. ~/.sds/files), that template will be used.
+    :param tmpl: template file name
+    :param dest: output file name
+    :param tmpl_dir: nominal directory containing the template
+    :param node_type: node type/role
+    :return: None
     """
     if tmpl_dir is None:
         tmpl_dir = get_user_files_path()


### PR DESCRIPTION
https://hysds-core.atlassian.net/browse/HC-348

i think i found a way to avoid using `cluster.py`
if `[tosca|figaro].js` is found in `~/.sds/files/` then it copies the files to `~/mozart/etc`
if not it instead copies `[tosca|figaro].template.js` to `~/mozart/etc`

also @pymonger what description/docstring should i add to `send_template_user_override` so future developers have a better understanding of it