### PR TITLE
HC-380: accept json content to receive revokes

### DIFF
--- a/sdscli/adapters/hysds/files/orch/grq/celeryconfig.py
+++ b/sdscli/adapters/hysds/files/orch/grq/celeryconfig.py
@@ -3,7 +3,7 @@ result_backend = "redis://:{{ MOZART_REDIS_PASSWORD }}@{{ MOZART_REDIS_PVT_IP }}
 
 task_serializer = "msgpack"
 result_serializer = "msgpack"
-accept_content = ["msgpack"]
+accept_content = ["msgpack", "json"]
 
 task_acks_late = True
 result_expires = 86400

--- a/sdscli/adapters/hysds/files/orch/metrics/celeryconfig.py
+++ b/sdscli/adapters/hysds/files/orch/metrics/celeryconfig.py
@@ -3,7 +3,7 @@ result_backend = "redis://:{{ MOZART_REDIS_PASSWORD }}@{{ MOZART_REDIS_PVT_IP }}
 
 task_serializer = "msgpack"
 result_serializer = "msgpack"
-accept_content = ["msgpack"]
+accept_content = ["msgpack", "json"]
 
 task_acks_late = True
 result_expires = 86400

--- a/sdscli/adapters/hysds/files/orch/mozart/celeryconfig.py
+++ b/sdscli/adapters/hysds/files/orch/mozart/celeryconfig.py
@@ -3,7 +3,7 @@ result_backend = "redis://:{{ MOZART_REDIS_PASSWORD }}@mozart-redis"
 
 task_serializer = "msgpack"
 result_serializer = "msgpack"
-accept_content = ["msgpack"]
+accept_content = ["msgpack", "json"]
 
 task_acks_late = True
 result_expires = 86400

--- a/sdscli/adapters/hysds/files/orch/verdi/celeryconfig.py
+++ b/sdscli/adapters/hysds/files/orch/verdi/celeryconfig.py
@@ -3,7 +3,7 @@ result_backend = "redis://:{{ MOZART_REDIS_PASSWORD }}@{{ MOZART_REDIS_PVT_IP }}
 
 task_serializer = "msgpack"
 result_serializer = "msgpack"
-accept_content = ["msgpack"]
+accept_content = ["msgpack", "json"]
 
 task_acks_late = True
 result_expires = 86400


### PR DESCRIPTION
This PR updates the celeryconfig.py.tmpl template to include json as acceptable content, which is the format of broadcasted revoke payloads.
This was tested in NISAR using the NASA demo pipeline (dev-e2e + ALOS L0B processed to RSLC, GSLC and GCOV).