### PR TITLE
HC-393: add target tracking metric for autoscaling that allows for 1:1 scaling of jobs to workers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ rsa==4.7
 s3transfer==0.3.0
 six==1.13.0
 tqdm==4.41.1
-urllib3==1.25.8
+urllib3==1.26.5
 vine==1.3.0
 wcwidth==0.1.8
 zipp==0.6.0

--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/update.py
+++ b/sdscli/adapters/hysds/update.py
@@ -193,6 +193,7 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
 
         # update verdi for code/config bundle
         set_bar_desc(bar, 'Ensuring HySDS venv')
+        execute(fab.rm_rf, '~/verdi', roles=[comp])
         execute(fab.ensure_venv, 'verdi',
                 update_bash_profile=False, roles=[comp])
         bar.update()


### PR DESCRIPTION
Details of this PR is shared with https://github.com/hysds/hysds/pull/128. 

Specific to this repository, this PR:
- add support to the sds CLI to allow end user to specify target tracking metric to use during `sds cloud asg create`
- detects target tracking metric per queue in `.sds/config` and specifies the corresponding CloudWatch metric name
- addresses an issue when running `sds update mozart` where the following error is encountered:
```
[100.104.10.132] out: ERROR: Exception:
[100.104.10.132] out: Traceback (most recent call last):
[100.104.10.132] out:   File "/export/home/hysdsops/verdi/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 164, in exc_logging_wrapper
[100.104.10.132] out:     status = run_func(*args)
[100.104.10.132] out:   File "/export/home/hysdsops/verdi/lib/python3.9/site-packages/pip/_internal/cli/req_command.py", line 205, in wrapper
[100.104.10.132] out:     return func(self, options, args)
[100.104.10.132] out:   File "/export/home/hysdsops/verdi/lib/python3.9/site-packages/pip/_internal/commands/install.py", line 404, in run
[100.104.10.132] out:     installed = install_given_reqs(
[100.104.10.132] out:   File "/export/home/hysdsops/verdi/lib/python3.9/site-packages/pip/_internal/req/__init__.py", line 68, in install_given_reqs
[100.104.10.132] out:     uninstalled_pathset = requirement.uninstall(auto_confirm=True)
[100.104.10.132] out:   File "/export/home/hysdsops/verdi/lib/python3.9/site-packages/pip/_internal/req/req_install.py", line 670, in uninstall
[100.104.10.132] out:     uninstalled_pathset = UninstallPathSet.from_dist(dist)
[100.104.10.132] out:   File "/export/home/hysdsops/verdi/lib/python3.9/site-packages/pip/_internal/req/req_uninstall.py", line 533, in from_dist
[100.104.10.132] out:     assert (
[100.104.10.132] out: AssertionError: Egg-link /export/home/hysdsops/verdi/ops/osaka-1.0.6 does not match installed location of osaka (at /export/home/hysdsops/verdi/ops/osaka)
[100.104.10.132] out:
Fatal error: run() received nonzero return code 2 while executing!
```
- mitigates outstanding CVE's