### PR TITLE
hotfix: SIGHUP being sent to supervisord process causing it to restart

### DIFF
--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -486,7 +486,7 @@ def grqd_start(force=False):
     mkdir('sciflo/run', context['OPS_USER'], context['OPS_USER'])
     if not exists('sciflo/run/supervisord.pid') or force:
         with prefix('source sciflo/bin/activate'):
-            run('supervisord')
+            run('supervisord', pty=False)
 
 
 def grqd_clean_start():
@@ -536,7 +536,7 @@ def install_ingest_pipeline():
 def mozartd_start(force=False):
     if not exists('mozart/run/supervisord.pid') or force:
         with prefix('source mozart/bin/activate'):
-            run('supervisord')
+            run('supervisord', pty=False)
 
 
 def mozartd_clean_start():
@@ -609,7 +609,7 @@ def npm_install_package_json(dest):
 def metricsd_start(force=False):
     if not exists('metrics/run/supervisord.pid') or force:
         with prefix('source metrics/bin/activate'):
-            run('supervisord')
+            run('supervisord', pty=False)
 
 
 def metricsd_clean_start():
@@ -654,7 +654,7 @@ def import_kibana(path):
 def verdid_start(force=False):
     if not exists('verdi/run/supervisord.pid') or force:
         with prefix('source verdi/bin/activate'):
-            run('supervisord')
+            run('supervisord', pty=False)
 
 
 def verdid_clean_start():


### PR DESCRIPTION
The sds CLI starts up the `supervisord` process on each PCM instance using a fabric's `run()` call. Currently when that happens, the spawned `supervisord` process also receives a `SIGHUP` which signals the `supervisord process to restart. For example, assume this sole process configured in `supervisord.conf` for mozart:

```
[program:instance_stats]
directory=/export/home/hysdsops/mozart/ops/hysds/scripts
command=/export/home/hysdsops/mozart/ops/hysds/scripts/log_instance_stats.py --interval 600
process_name=%(program_name)s
priority=1
numprocs=1
numprocs_start=0
redirect_stderr=true
stdout_logfile=%(here)s/../log/%(program_name)s.log
stdout_logfile_maxbytes=100MB
stdout_logfile_backups=10
startsecs=10
```

When running `supervisord` manually, the log shows:
```
2021-12-02 00:06:05,045 INFO RPC interface 'supervisor' initialized  
2021-12-02 00:06:05,045 INFO RPC interface 'supervisor' initialized  
2021-12-02 00:06:05,045 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2021-12-02 00:06:05,046 INFO daemonizing the supervisord process
2021-12-02 00:06:05,047 INFO supervisord started with pid 108215
2021-12-02 00:06:06,049 INFO spawned: 'instance_stats' with pid 108217
2021-12-02 00:06:16,250 INFO success: instance_stats entered RUNNING state, process has stayed up for > than 10 seconds (startsecs)
```

However when running it though the sdscli (or via fabric):
```
fab -f ~/mozart/ops/sdscli/sdscli/adapters/hysds/fabfile.py -R mozart mozartd_start
```

the log shows:
```
2021-12-02 00:13:56,187 INFO RPC interface 'supervisor' initialized
2021-12-02 00:13:56,187 INFO RPC interface 'supervisor' initialized
2021-12-02 00:13:56,187 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2021-12-02 00:13:56,188 INFO daemonizing the supervisord process
2021-12-02 00:13:56,189 INFO supervisord started with pid 110247
2021-12-02 00:13:57,192 INFO spawned: 'instance_stats' with pid 110249
2021-12-02 00:13:57,192 WARN received SIGHUP indicating restart request
2021-12-02 00:13:57,192 INFO waiting for instance_stats to die
2021-12-02 00:14:00,390 INFO waiting for instance_stats to die
2021-12-02 00:14:03,393 INFO waiting for instance_stats to die
2021-12-02 00:14:06,396 INFO waiting for instance_stats to die
2021-12-02 00:14:07,397 WARN killing 'instance_stats' (110249) with SIGKILL
2021-12-02 00:14:07,399 INFO stopped: instance_stats (terminated by SIGKILL)
2021-12-02 00:14:07,404 INFO RPC interface 'supervisor' initialized
2021-12-02 00:14:07,404 INFO RPC interface 'supervisor' initialized
2021-12-02 00:14:07,404 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2021-12-02 00:14:07,404 INFO supervisord started with pid 110247
2021-12-02 00:14:08,407 INFO spawned: 'instance_stats' with pid 110252
2021-12-02 00:14:18,610 INFO success: instance_stats entered RUNNING state, process has stayed up for > than 10 seconds (startsecs)
```

Note the log lines:
```
2021-12-02 00:13:57,192 WARN received SIGHUP indicating restart request
2021-12-02 00:13:57,192 INFO waiting for instance_stats to die
2021-12-02 00:14:00,390 INFO waiting for instance_stats to die
2021-12-02 00:14:03,393 INFO waiting for instance_stats to die
2021-12-02 00:14:06,396 INFO waiting for instance_stats to die
2021-12-02 00:14:07,397 WARN killing 'instance_stats' (110249) with SIGKILL
2021-12-02 00:14:07,399 INFO stopped: instance_stats (terminated by SIGKILL)
```

For some reason, the fabric `run()`, command sends a SIGHUP immediately after starting up the process which tells supervisord to kill current processes and start them up again. To fix that, we need to specify the `pty=False` option. 

Once approved and merged, will regenerate the v4.0.1-beta.7 release.