### PR TITLE
HC-367: Update to support upgrade to latest Pallet Project versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ importlib-metadata==1.4.0
 Jinja2==2.11.3
 jmespath==0.9.4
 kombu==4.6.7
-MarkupSafe==1.1.1
+MarkupSafe==2.0.1
 more-itertools==8.1.0
 paramiko==2.7.1
 prompt-toolkit==1.0.18

--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "awscli>=1.17.1",
         "boto3>=1.11.1",
         "fabric3>=1.14.post1",
-        "Jinja2>=2.10.1",
+        "Jinja2>=3.0.0,<4.0.0",
     ],
     entry_points={"console_scripts": ["sds=sdscli.command_line:main"]},
     package_data={


### PR DESCRIPTION
This PR updates the MarkupSafe and Jinja pins to support the updates to the latest Pallet Project versions (Flask 2.x).