### PR TITLE
HC-419 - update "sds status" to handle clusters without a CI instance

### DIFF
--- a/sdscli/adapters/hysds/status.py
+++ b/sdscli/adapters/hysds/status.py
@@ -156,9 +156,12 @@ def print_status(conf, comp, debug=False):
     """"Status of component."""
 
     print_component_header(comp)
-    print_tps_status(conf, comp, debug)
-    print_supervisor_header(comp)
-    execute(fab.status, roles=[comp])
+    if len(fab.env.roledefs[comp]) == 1 and "None" not in fab.env.roledefs[comp]:
+        print_tps_status(conf, comp, debug)
+        print_supervisor_header(comp)
+        execute(fab.status, roles=[comp])
+    else:
+        print(f"No configured host(s) for role: {comp}. Skipping.")
 
 
 def status_comp(comp, conf, debug=False):


### PR DESCRIPTION
Related Jira ticket: https://hysds-core.atlassian.net/browse/HC-419

This PR updates the sdscli `status` subcommand so that it can detect if a component is undefined and bypass giving that component's status. For example, if the `CI_PVT_IP` parameter is undefined in `~/.sds/config`:
```
$ grep CI_ ~/.sds/config
CI_PVT_IP:
CI_PUB_IP:
CI_FQDN:
```
The following error will be given when running `sds status`:
```
########################################
ci
########################################
----------------------------------------
third-party services
----------------------------------------
[None] Executing task 'systemctl'
!!! Parallel execution exception under host 'None':
Process None:
Traceback (most recent call last):
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/network.py", line 478, in connect
    client.connect(**kwargs)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/paramiko/client.py", line 340, in connect
    to_try = list(self._families_and_addresses(hostname, port))
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/paramiko/client.py", line 203, in _families_and_
addresses
    addrinfos = socket.getaddrinfo(
  File "/export/home/hysdsops/conda/lib/python3.9/socket.py", line 954, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/export/home/hysdsops/conda/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/export/home/hysdsops/conda/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/tasks.py", line 242, in inner
    submit(task.run(*args, **kwargs))
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
  File "/export/home/hysdsops/mozart/ops/sdscli/sdscli/adapters/hysds/fabfile.py", line 426, in systemctl
    return run('sudo systemctl %s %s' % (cmd, service), pty=False)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/network.py", line 692, in host_prompting_
wrapper
    return func(*args, **kwargs)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/operations.py", line 1092, in run
    return _run_command(
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/operations.py", line 935, in _run_command
    channel=default_channel(), command=wrapped_command, pty=pty,
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/state.py", line 435, in default_channel
    chan = _open_session()
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/state.py", line 416, in _open_session
    transport = connections[env.host_string].get_transport()
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/network.py", line 156, in __getitem__
    self.connect(key)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/network.py", line 147, in connect
    self[key] = connect(
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/fabric/network.py", line 578, in connect
    raise NetworkError('Name lookup failed for %s' % host, e)
fabric.exceptions.NetworkError: Name lookup failed for None

Fatal error: One or more hosts failed while executing task 'systemctl'

Underlying exception:
    Name lookup failed for None

Aborting.
```

With this fix, the following is now output:
```
########################################
ci
########################################
No configured host(s) for role: ci. Skipping.
```