### PR TITLE
move to fab-classic as it has active support and development

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.7"
+__version__ = "1.2.0"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'elasticsearch-dsl>=7.0.0,<=7.4.0',
         "awscli>=1.17.1",
         "boto3>=1.11.1",
-        "fabric3>=1.14.post1",
+        "fab-classic>=1.19.2",
         "Jinja2>=3.0.0,<4.0.0",
     ],
     entry_points={"console_scripts": ["sds=sdscli.command_line:main"]},


### PR DESCRIPTION
`fabric3` errors out running with this error when using python3.10:
```python
from collections import Mapping
``` 
it should not be:
```python
from collections.abc import Mapping
```

[`fab-classic`](https://pypi.org/project/fab-classic/) made a fix to that and also wrapped the fix in a `try/except` block for backwards compatibility: [their python 3.10 PR](https://github.com/ploxiln/fab-classic/pull/59/files#diff-d378f4c2286c57955479a7816c3d3f221e11d05b7215662542282eefed2c8f54)

`fabric/main.py`
```python
import inspect
from optparse import OptionParser
from importlib import import_module
try:
    from collections.abc import Mapping
except ImportError:
    from collections import Mapping

import six
```

@pymonger was able to test this out and confirmed that `sdscli` is working as normal after we used this `fabric` fork instead
@mcayanan  will also merge this into `develop-v5` afterwards