### PR TITLE
NSDS-2584 - Implement rollover of old task, worker, event ES docs on Mozart ES

### DIFF
--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -620,13 +620,13 @@ def rabbitmq_queues_flush():
 def mozart_es_flush():
     ctx = get_context()
     run('curl -XDELETE http://{MOZART_ES_PVT_IP}:9200/_template/*_status'.format(**ctx))
-    run('~/mozart/ops/hysds/scripts/clean_job_status_indexes.sh http://{MOZART_ES_PVT_IP}:9200'.format(
+    run('~/mozart/ops/hysds/scripts/clean_indices_from_alias.py http://{MOZART_ES_PVT_IP}:9200 job_status-current'.format(
         **ctx))
-    run('~/mozart/ops/hysds/scripts/clean_task_status_indexes.sh http://{MOZART_ES_PVT_IP}:9200'.format(
+    run('~/mozart/ops/hysds/scripts/clean_indices_from_alias.py http://{MOZART_ES_PVT_IP}:9200 task_status-current'.format(
         **ctx))
-    run('~/mozart/ops/hysds/scripts/clean_worker_status_indexes.sh http://{MOZART_ES_PVT_IP}:9200'.format(
+    run('~/mozart/ops/hysds/scripts/clean_indices_from_alias.py http://{MOZART_ES_PVT_IP}:9200 event_status-current'.format(
         **ctx))
-    run('~/mozart/ops/hysds/scripts/clean_event_status_indexes.sh http://{MOZART_ES_PVT_IP}:9200'.format(
+    run('~/mozart/ops/hysds/scripts/clean_indices_from_alias.py http://{MOZART_ES_PVT_IP}:9200 worker_status-current'.format(
         **ctx))
     #run('~/mozart/ops/hysds/scripts/clean_job_spec_container_indexes.sh http://{MOZART_ES_PVT_IP}:9200'.format(**ctx))
 

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -619,7 +619,7 @@ def rabbitmq_queues_flush():
 
 def mozart_es_flush():
     ctx = get_context()
-    run('curl -XDELETE http://{MOZART_ES_PVT_IP}:9200/_template/*_status'.format(**ctx))
+    run('curl -XDELETE http://{MOZART_ES_PVT_IP}:9200/_index_template/*_status'.format(**ctx))
     run('~/mozart/ops/hysds/scripts/clean_indices_from_alias.py http://{MOZART_ES_PVT_IP}:9200 job_status-current'.format(
         **ctx))
     run('~/mozart/ops/hysds/scripts/clean_indices_from_alias.py http://{MOZART_ES_PVT_IP}:9200 task_status-current'.format(

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -622,7 +622,7 @@ def rabbitmq_queues_flush():
 
 def mozart_es_flush():
     ctx = get_context()
-    run('curl -XDELETE http://{MOZART_ES_PVT_IP}:9200/_index_template/*_status'.format(**ctx))
+    #run('curl -XDELETE http://{MOZART_ES_PVT_IP}:9200/_index_template/*_status'.format(**ctx))
     run('~/mozart/ops/hysds/scripts/clean_indices_from_alias.py http://{MOZART_ES_PVT_IP}:9200 job_status-current'.format(
         **ctx))
     run('~/mozart/ops/hysds/scripts/clean_indices_from_alias.py http://{MOZART_ES_PVT_IP}:9200 task_status-current'.format(

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -488,10 +488,13 @@ def install_es_policy():
     )
     run(f"curl -XPUT 'localhost:9200/_ilm/policy/ilm_policy_mozart?pretty' -H 'Content-Type: application/json' -d@{target_file}")
 
+
 def install_mozart_es_templates():
     # install index templates
     # Only job_status.template has ILM policy attached
     # HC-451 will focus on adding ILM to worker, task, and event status indices
+
+    # template files located in ~/.sds/files
     templates = [
         "job_status.template",
         "worker_status.template",

--- a/sdscli/adapters/hysds/files/event_status.template
+++ b/sdscli/adapters/hysds/files/event_status.template
@@ -95,6 +95,7 @@
       },
       "aliases": {
         "job_status": {},
+        "event_status": {},
         "event_status-current": {}
       }
   }

--- a/sdscli/adapters/hysds/files/event_status.template
+++ b/sdscli/adapters/hysds/files/event_status.template
@@ -76,7 +76,10 @@
       "settings": {
         "number_of_shards": 8,
         "index": {
-          "refresh_interval": "5s"
+          "refresh_interval": "5s",
+          "lifecycle": {
+            "name": "ilm_policy_mozart"
+          }
         },
         "analysis": {
           "analyzer": {
@@ -91,7 +94,8 @@
         }
       },
       "aliases": {
-        "job_status": {}
+        "job_status": {},
+        "event_status-current": {}
       }
   }
 }

--- a/sdscli/adapters/hysds/files/task_status.template
+++ b/sdscli/adapters/hysds/files/task_status.template
@@ -125,7 +125,10 @@
       "settings": {
         "number_of_shards": 8,
         "index": {
-          "refresh_interval": "5s"
+          "refresh_interval": "5s",
+          "lifecycle": {
+            "name": "ilm_policy_mozart"
+          }
         },
         "analysis": {
           "analyzer": {
@@ -141,6 +144,7 @@
       },
       "aliases": {
         "task_status": {},
+        "task_status-current": {},
         "job_status": {}
       }
   }

--- a/sdscli/adapters/hysds/files/worker_status.template
+++ b/sdscli/adapters/hysds/files/worker_status.template
@@ -125,7 +125,10 @@
       "settings": {
         "number_of_shards": 8,
         "index": {
-          "refresh_interval": "5s"
+          "refresh_interval": "5s",
+          "lifecycle": {
+            "name": "ilm_policy_mozart"
+          }
         },
         "analysis": {
           "analyzer": {
@@ -141,6 +144,7 @@
       },
       "aliases": {
         "worker_status": {},
+        "worker_status-current": {},
         "job_status": {}
       }
   }


### PR DESCRIPTION
https://jira.jpl.nasa.gov/browse/NSDS-2584

related PR: https://github.com/hysds/hysds/pull/153

change(s):
- added `ilm_policy_mozart` lifecycle to `event`, `task` and `worker`
- added `*_status-current` alias to `event`, `task` and `worker`
- using `clean_indices_from_alias.py` script to clean indices by alias

<img width="1003" alt="Screenshot 2023-03-08 at 10 50 21 AM" src="https://user-images.githubusercontent.com/13371881/223823800-2ecf7c21-3c74-4819-b902-31ad4fe60773.png">
