### PR TITLE
hotfix: show product/input counts correctly

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/files/kibana_dashboard_import/job-dashboards.json
+++ b/sdscli/adapters/hysds/files/kibana_dashboard_import/job-dashboards.json
@@ -1,521 +1,1090 @@
 {
-  "version": "6.4.2",
+  "version": "7.10.2",
   "objects": [
+    {
+      "id": "cb40a460-5ad3-11e7-8e6a-cbf606444333",
+      "type": "dashboard",
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T16:59:24.844Z",
+      "version": "WzEyNzAsMV0=",
+      "attributes": {
+        "title": "Job Metrics",
+        "hits": 0,
+        "description": "",
+        "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"1\",\"w\":48,\"x\":0,\"y\":0},\"panelIndex\":\"1\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":25,\"i\":\"2\",\"w\":16,\"x\":0,\"y\":15},\"panelIndex\":\"2\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_1\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":25,\"i\":\"3\",\"w\":16,\"x\":16,\"y\":15},\"panelIndex\":\"3\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_2\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":25,\"i\":\"4\",\"w\":16,\"x\":32,\"y\":15},\"panelIndex\":\"4\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_3\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":true}},\"gridData\":{\"h\":25,\"i\":\"5\",\"w\":25,\"x\":23,\"y\":40},\"panelIndex\":\"5\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_4\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":26,\"i\":\"6\",\"w\":23,\"x\":0,\"y\":64},\"panelIndex\":\"6\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_5\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":25,\"i\":\"7\",\"w\":25,\"x\":23,\"y\":65},\"panelIndex\":\"7\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_6\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":11,\"i\":\"8\",\"w\":48,\"x\":0,\"y\":90},\"panelIndex\":\"8\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_7\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":15,\"i\":\"9\",\"w\":48,\"x\":0,\"y\":101},\"panelIndex\":\"9\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_8\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"10\",\"w\":48,\"x\":0,\"y\":196},\"panelIndex\":\"10\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_9\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":12,\"i\":\"11\",\"w\":47,\"x\":0,\"y\":211},\"panelIndex\":\"11\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_10\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"12\",\"w\":48,\"x\":0,\"y\":223},\"panelIndex\":\"12\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_11\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"13\",\"w\":48,\"x\":0,\"y\":252},\"panelIndex\":\"13\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_12\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":14,\"i\":\"14\",\"w\":48,\"x\":0,\"y\":238},\"panelIndex\":\"14\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_13\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"15\",\"w\":47,\"x\":0,\"y\":267},\"panelIndex\":\"15\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_14\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"16\",\"w\":48,\"x\":0,\"y\":275},\"panelIndex\":\"16\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_15\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"17\",\"w\":48,\"x\":0,\"y\":290},\"panelIndex\":\"17\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_16\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":12,\"i\":\"18\",\"w\":48,\"x\":0,\"y\":305},\"panelIndex\":\"18\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_17\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"19\",\"w\":48,\"x\":0,\"y\":317},\"panelIndex\":\"19\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_18\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":11,\"i\":\"20\",\"w\":48,\"x\":0,\"y\":332},\"panelIndex\":\"20\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_19\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"21\",\"w\":48,\"x\":0,\"y\":358},\"panelIndex\":\"21\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_20\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"22\",\"w\":48,\"x\":0,\"y\":366},\"panelIndex\":\"22\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_21\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"23\",\"w\":48,\"x\":0,\"y\":343},\"panelIndex\":\"23\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_22\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":10,\"i\":\"24\",\"w\":47,\"x\":0,\"y\":142},\"panelIndex\":\"24\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_23\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":10,\"i\":\"25\",\"w\":47,\"x\":0,\"y\":168},\"panelIndex\":\"25\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_24\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":9,\"i\":\"26\",\"w\":48,\"x\":0,\"y\":116},\"panelIndex\":\"26\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_25\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":17,\"i\":\"27\",\"w\":48,\"x\":0,\"y\":125},\"panelIndex\":\"27\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_26\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":16,\"i\":\"28\",\"w\":48,\"x\":0,\"y\":152},\"panelIndex\":\"28\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_27\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"h\":18,\"i\":\"29\",\"w\":48,\"x\":0,\"y\":178},\"panelIndex\":\"29\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_28\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":24,\"i\":\"30\",\"w\":23,\"x\":0,\"y\":40},\"panelIndex\":\"30\",\"version\":\"7.10.2\",\"panelRefName\":\"panel_29\"}]",
+        "optionsJSON": "{\"darkTheme\":false,\"useMargins\":false}",
+        "version": 1,
+        "timeRestore": false,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[]}"
+        }
+      },
+      "references": [
+        {
+          "name": "panel_0",
+          "type": "visualization",
+          "id": "acb6f440-5ad3-11e7-8e6a-cbf606444333"
+        },
+        {
+          "name": "panel_1",
+          "type": "visualization",
+          "id": "38ea3850-5ad4-11e7-8e6a-cbf606444333"
+        },
+        {
+          "name": "panel_2",
+          "type": "visualization",
+          "id": "b06f4be0-5ad4-11e7-8e6a-cbf606444333"
+        },
+        {
+          "name": "panel_3",
+          "type": "visualization",
+          "id": "2f467fa0-5ad6-11e7-8e6a-cbf606444333"
+        },
+        {
+          "name": "panel_4",
+          "type": "visualization",
+          "id": "f31a3920-5ad7-11e7-8e6a-cbf606444333"
+        },
+        {
+          "name": "panel_5",
+          "type": "visualization",
+          "id": "8a425c10-5ad8-11e7-8e6a-cbf606444333"
+        },
+        {
+          "name": "panel_6",
+          "type": "visualization",
+          "id": "2cf9f030-5ad9-11e7-8e6a-cbf606444333"
+        },
+        {
+          "name": "panel_7",
+          "type": "visualization",
+          "id": "ff3e1030-5ad9-11e7-8e6a-cbf606444333"
+        },
+        {
+          "name": "panel_8",
+          "type": "visualization",
+          "id": "e8c21a90-5b47-11e7-9160-a9831305fdae"
+        },
+        {
+          "name": "panel_9",
+          "type": "visualization",
+          "id": "22296d50-5b49-11e7-9160-a9831305fdae"
+        },
+        {
+          "name": "panel_10",
+          "type": "visualization",
+          "id": "ff5c3fc0-5b4b-11e7-9160-a9831305fdae"
+        },
+        {
+          "name": "panel_11",
+          "type": "visualization",
+          "id": "0ec46c60-5b4e-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_12",
+          "type": "visualization",
+          "id": "96a964f0-5b4e-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_13",
+          "type": "visualization",
+          "id": "5d7772b0-5b50-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_14",
+          "type": "visualization",
+          "id": "d56a3c30-5b50-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_15",
+          "type": "visualization",
+          "id": "249ee080-5b51-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_16",
+          "type": "visualization",
+          "id": "3e637200-5b52-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_17",
+          "type": "visualization",
+          "id": "7cc6f8f0-5b52-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_18",
+          "type": "visualization",
+          "id": "96722b80-5b52-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_19",
+          "type": "visualization",
+          "id": "b2fdc1b0-5b52-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_20",
+          "type": "visualization",
+          "id": "d3477150-5b52-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_21",
+          "type": "visualization",
+          "id": "e8273920-5b52-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_22",
+          "type": "visualization",
+          "id": "4fa3fd90-5b53-11e7-9c6a-6d89ce62415a"
+        },
+        {
+          "name": "panel_23",
+          "type": "visualization",
+          "id": "af7c6180-15f0-11ea-a3e1-b14356404360"
+        },
+        {
+          "name": "panel_24",
+          "type": "visualization",
+          "id": "897ccdd0-15f5-11ea-a3e1-b14356404360"
+        },
+        {
+          "name": "panel_25",
+          "type": "visualization",
+          "id": "181c4f90-15f9-11ea-a3e1-b14356404360"
+        },
+        {
+          "name": "panel_26",
+          "type": "visualization",
+          "id": "7d7aeef0-15f9-11ea-a3e1-b14356404360"
+        },
+        {
+          "name": "panel_27",
+          "type": "visualization",
+          "id": "15932c50-15fc-11ea-a3e1-b14356404360"
+        },
+        {
+          "name": "panel_28",
+          "type": "visualization",
+          "id": "541a4b60-15fd-11ea-a3e1-b14356404360"
+        },
+        {
+          "name": "panel_29",
+          "type": "visualization",
+          "id": "5433f870-15fe-11ea-a3e1-b14356404360"
+        }
+      ],
+      "migrationVersion": {
+        "dashboard": "7.9.3"
+      }
+    },
     {
       "id": "acb6f440-5ad3-11e7-8e6a-cbf606444333",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzExLDFd",
       "attributes": {
         "title": "Jobs Executed Over Time",
-        "visState": "{\"title\":\"Jobs Executed Over Time\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.time_end per minute\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.time_end\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Jobs Executed Over Time\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.time_end per minute\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.time_end\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "38ea3850-5ad4-11e7-8e6a-cbf606444333",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzEyLDFd",
       "attributes": {
         "title": "Jobs By Type",
         "visState": "{\"title\":\"Jobs By Type\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":false,\"truncate\":200},\"position\":\"left\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":true,\"rotate\":75,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"bottom\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"job_type.keyword\",\"size\":100,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "b06f4be0-5ad4-11e7-8e6a-cbf606444333",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzEzLDFd",
       "attributes": {
         "title": "Jobs By Instance Type",
         "visState": "{\"title\":\"Jobs By Instance Type\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":false,\"truncate\":200},\"position\":\"left\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":true,\"rotate\":75,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"bottom\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"job.job_info.facts.ec2_instance_type.keyword\",\"size\":100,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "2f467fa0-5ad6-11e7-8e6a-cbf606444333",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzE0LDFd",
       "attributes": {
         "title": "Jobs By Exit Code",
         "visState": "{\"title\":\"Jobs By Exit Code\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":false,\"truncate\":200},\"position\":\"left\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":true,\"rotate\":75,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"bottom\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"job.job_info.status\",\"size\":100,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "f31a3920-5ad7-11e7-8e6a-cbf606444333",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:54:45.486Z",
-      "version": 4,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzE1LDFd",
       "attributes": {
         "title": "Mean Container Execution Time By Job Type",
         "visState": "{\"title\":\"Mean Container Execution Time By Job Type\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":false,\"truncate\":200},\"position\":\"left\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average job.job_info.cmd_duration\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":true,\"rotate\":75,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"bottom\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average job.job_info.cmd_duration\"},\"type\":\"value\"}],\"type\":\"histogram\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.cmd_duration\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"job_type.keyword\",\"size\":100,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "8a425c10-5ad8-11e7-8e6a-cbf606444333",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzE2LDFd",
       "attributes": {
         "title": "Mean Work Dir Volume By Job Type",
         "visState": "{\"title\":\"Mean Work Dir Volume By Job Type\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":false,\"truncate\":200},\"position\":\"left\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average job.job_info.metrics.job_dir_size\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":true,\"rotate\":75,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"bottom\",\"scale\":{\"mode\":\"normal\",\"type\":\"log\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average job.job_info.metrics.job_dir_size\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.job_dir_size\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"job_type.keyword\",\"size\":100,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "2cf9f030-5ad9-11e7-8e6a-cbf606444333",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzE3LDFd",
       "attributes": {
         "title": "Mean Product Volume by Job Type",
         "visState": "{\"title\":\"Mean Product Volume by Job Type\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":false,\"truncate\":200},\"position\":\"left\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average job.job_info.metrics.products_staged.disk_usage\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":true,\"rotate\":75,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"bottom\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average job.job_info.metrics.products_staged.disk_usage\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"job_type.keyword\",\"size\":100,\"order\":\"desc\",\"orderBy\":\"_term\"}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "ff3e1030-5ad9-11e7-8e6a-cbf606444333",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:19:19.125Z",
-      "version": 2,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzE4LDFd",
       "attributes": {
         "title": "Job Execution Metrics (seconds)",
         "visState": "{\"title\":\"Job Execution Metrics (seconds)\",\"type\":\"metric\",\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Jobs Executed\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.duration\",\"customLabel\":\"min duration\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.duration\",\"percents\":[50],\"customLabel\":\"duration\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.duration\",\"customLabel\":\"mean duration\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.duration\",\"customLabel\":\"max duration\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.duration\",\"customLabel\":\"std_dev\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "e8c21a90-5b47-11e7-9160-a9831305fdae",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:20:32.039Z",
-      "version": 2,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzE5LDFd",
       "attributes": {
         "title": "Job Execution Time Distribution",
         "visState": "{\"title\":\"Job Execution Time Distribution\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.cmd_duration\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}],\"type\":\"histogram\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.duration\",\"interval\":60,\"extended_bounds\":{}}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "22296d50-5b49-11e7-9160-a9831305fdae",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzIwLDFd",
       "attributes": {
         "title": "Products Generated Over Time",
-        "visState": "{\"title\":\"Products Generated Over Time\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.products_staged.time_end per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.time_end\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Products Generated Over Time\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.products_staged.time_end per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.time_end\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "ff5c3fc0-5b4b-11e7-9160-a9831305fdae",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T16:44:03.836Z",
+      "version": "Wzc3NiwxXQ==",
       "attributes": {
         "title": "Product Volume",
-        "visState": "{\"title\":\"Product Volume\",\"type\":\"metric\",\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"product_staged\",\"customLabel\":\"Total Products\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"min product size\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"percents\":[50],\"customLabel\":\"product size\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"mean product size\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"max product size\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"std_dev\"}}]}",
+        "visState": "{\"title\":\"Product Volume\",\"type\":\"metric\",\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.id.keyword\",\"customLabel\":\"Total Products\"},\"schema\":\"metric\"},{\"id\":\"7\",\"enabled\":true,\"type\":\"sum\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"Total Volume\"},\"schema\":\"metric\"},{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"Min Product Size\"},\"schema\":\"metric\"},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"Median Product Size\"},\"schema\":\"metric\"},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"Mean Product Size\"},\"schema\":\"metric\"},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"Max Product Size\"},\"schema\":\"metric\"},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"customLabel\":\"Standard Deviation\"},\"schema\":\"metric\"}],\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "name": "search_0",
+          "type": "search",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "0ec46c60-5b4e-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzIyLDFd",
       "attributes": {
         "title": "Product Volume Distribution",
         "visState": "{\"title\":\"Product Volume Distribution\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.products_staged.disk_usage\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.disk_usage\",\"interval\":1073741824,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "96a964f0-5b4e-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzIzLDFd",
       "attributes": {
         "title": "Max Product Transfer Rate Over Time (per second)",
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"job.job_info.metrics.products_staged.time_end\",\"interval\":\"h\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"},{\"enabled\":true,\"id\":\"4\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\"},\"schema\":\"metric\",\"type\":\"max\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.products_staged.time_end per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"4\",\"label\":\"Max job.job_info.metrics.products_staged.transfer_rate\"},\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"lineWidth\":2,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max job.job_info.metrics.products_staged.transfer_rate\"},\"type\":\"value\"}]},\"title\":\"Max Product Transfer Rate Over Time (per second)\",\"type\":\"histogram\"}",
+        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"2\",\"params\":{\"extended_bounds\":{},\"field\":\"job.job_info.metrics.products_staged.time_end\",\"interval\":\"h\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"},{\"enabled\":true,\"id\":\"4\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\"},\"schema\":\"metric\",\"type\":\"max\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.products_staged.time_end per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"4\",\"label\":\"Max job.job_info.metrics.products_staged.transfer_rate\"},\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"lineWidth\":2,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max job.job_info.metrics.products_staged.transfer_rate\"},\"type\":\"value\"}]},\"title\":\"Max Product Transfer Rate Over Time (per second)\",\"type\":\"histogram\"}",
         "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "5d7772b0-5b50-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T16:53:55.622Z",
+      "version": "WzEwMzAsMV0=",
       "attributes": {
         "title": "Product TX Rate",
-        "visState": "{\"title\":\"Product TX Rate\",\"type\":\"metric\",\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"customLabel\":\"min rate\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"percents\":[50],\"customLabel\":\"rate\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"customLabel\":\"mean rate\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"customLabel\":\"max rate\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"customLabel\":\"std_dev\"}}]}",
+        "visState": "{\"title\":\"Product TX Rate\",\"type\":\"metric\",\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"customLabel\":\"min rate\"},\"schema\":\"metric\"},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"customLabel\":\"rate\"},\"schema\":\"metric\"},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"customLabel\":\"mean rate\"},\"schema\":\"metric\"},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"customLabel\":\"max rate\"},\"schema\":\"metric\"},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.transfer_rate\",\"customLabel\":\"std_dev\"},\"schema\":\"metric\"}],\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "name": "search_0",
+          "type": "search",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "d56a3c30-5b50-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzI1LDFd",
       "attributes": {
         "title": "Product Transfer Time",
         "visState": "{\"title\":\"Product Transfer Time\",\"type\":\"metric\",\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.duration\",\"customLabel\":\"min seconds\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.duration\",\"percents\":[50],\"customLabel\":\"seconds\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.duration\",\"customLabel\":\"mean seconds\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.duration\",\"customLabel\":\"max seconds\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.duration\",\"customLabel\":\"std_dev\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "249ee080-5b51-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzI2LDFd",
       "attributes": {
         "title": "Product Transfer Time Distribution",
         "visState": "{\"title\":\"Product Transfer Time Distribution\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.products_staged.duration\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.products_staged.duration\",\"interval\":5,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "3e637200-5b52-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzI3LDFd",
       "attributes": {
         "title": "Inputs Downloaded Over Time",
-        "visState": "{\"title\":\"Inputs Downloaded Over Time\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.inputs_localized.time_end per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.time_end\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Inputs Downloaded Over Time\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.inputs_localized.time_end per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.time_end\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "7cc6f8f0-5b52-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T16:42:20.425Z",
+      "version": "WzY4NiwxXQ==",
       "attributes": {
         "title": "Input Volume",
-        "visState": "{\"title\":\"Input Volume\",\"type\":\"metric\",\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"input_localized\",\"customLabel\":\"Total Inputs\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"min input size\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"percents\":[50],\"customLabel\":\"input size\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"mean input size\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"max input size\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"std_dev\"}}]}",
+        "visState": "{\"title\":\"Input Volume\",\"type\":\"metric\",\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.url.keyword\",\"customLabel\":\"Total Inputs\"},\"schema\":\"metric\"},{\"id\":\"7\",\"enabled\":true,\"type\":\"sum\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"Total Volume\"},\"schema\":\"metric\"},{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"Min Input Size\"},\"schema\":\"metric\"},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"Median Input Size\"},\"schema\":\"metric\"},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"Mean Input Size\"},\"schema\":\"metric\"},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"Max Input Size\"},\"schema\":\"metric\"},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"customLabel\":\"Standard Deviation\"},\"schema\":\"metric\"}],\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "name": "search_0",
+          "type": "search",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "96722b80-5b52-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzI5LDFd",
       "attributes": {
         "title": "Input Volume Distribution",
         "visState": "{\"title\":\"Input Volume Distribution\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.inputs_localized.disk_usage\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"interval\":1073741824,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "b2fdc1b0-5b52-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzMwLDFd",
       "attributes": {
         "title": "Input TX Rate",
         "visState": "{\"title\":\"Input TX Rate\",\"type\":\"metric\",\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.transfer_rate\",\"customLabel\":\"min rate\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.transfer_rate\",\"percents\":[50],\"customLabel\":\"rate\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.transfer_rate\",\"customLabel\":\"mean rate\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.transfer_rate\",\"customLabel\":\"max rate\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.transfer_rate\",\"customLabel\":\"std_dev\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "d3477150-5b52-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzMxLDFd",
       "attributes": {
         "title": "Input Transfer Time",
         "visState": "{\"title\":\"Input Transfer Time\",\"type\":\"metric\",\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.duration\",\"customLabel\":\"min seconds\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.duration\",\"percents\":[50],\"customLabel\":\"seconds\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.duration\",\"customLabel\":\"mean seconds\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.duration\",\"customLabel\":\"max seconds\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.duration\",\"customLabel\":\"std_dev\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "e8273920-5b52-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzMyLDFd",
       "attributes": {
         "title": "Input Transfer Time Distribution",
         "visState": "{\"title\":\"Input Transfer Time Distribution\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.inputs_localized.duration\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.duration\",\"interval\":5,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "4fa3fd90-5b53-11e7-9c6a-6d89ce62415a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:55.497Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzMzLDFd",
       "attributes": {
         "title": "Max Input Transfer Rate Over Time (per second)",
-        "visState": "{\"title\":\"Max Input Transfer Rate Over Time (per second)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.inputs_localized.time_end per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"4\",\"label\":\"Max job.job_info.metrics.inputs_localized.transfer_rate\"},\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"lineWidth\":2,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max job.job_info.metrics.inputs_localized.transfer_rate\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.time_end\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.transfer_rate\"}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Input Transfer Rate Over Time (per second)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.inputs_localized.time_end per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"4\",\"label\":\"Max job.job_info.metrics.inputs_localized.transfer_rate\"},\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"lineWidth\":2,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max job.job_info.metrics.inputs_localized.transfer_rate\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.time_end\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.inputs_localized.transfer_rate\"}}],\"listeners\":{}}",
         "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "af7c6180-15f0-11ea-a3e1-b14356404360",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:31:35.420Z",
-      "version": 6,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzM0LDFd",
       "attributes": {
         "title": "Container Total CPU Usage (seconds)",
         "visState": "{\"title\":\"Container Total CPU Usage (seconds)\",\"type\":\"metric\",\"params\":{\"addLegend\":false,\"addTooltip\":true,\"metric\":{\"colorSchema\":\"Green to Red\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"invertColors\":false,\"labels\":{\"show\":true},\"metricColorMode\":\"None\",\"percentageMode\":false,\"style\":{\"bgColor\":false,\"bgFill\":\"#000\",\"fontSize\":20,\"labelColor\":false,\"subText\":\"\"},\"useRanges\":false},\"type\":\"metric\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Containers Executed\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"customLabel\":\"min total CPU usage\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"percents\":[50],\"customLabel\":\"total CPU usage\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"customLabel\":\"mean total CPU usage\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"customLabel\":\"max total CPU usage\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"percentiles\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"percents\":[16,84],\"customLabel\":\"total CPU usage\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "897ccdd0-15f5-11ea-a3e1-b14356404360",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:30:26.543Z",
-      "version": 4,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzM1LDFd",
       "attributes": {
         "title": "Container Memory Usage",
         "visState": "{\"title\":\"Container Memory Usage\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Containers Executed\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"customLabel\":\"min memory usage\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"percents\":[50],\"customLabel\":\"memory usage\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"customLabel\":\"mean memory usage\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"customLabel\":\"max memory usage\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"percentiles\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"percents\":[16,84],\"customLabel\":\"memory usage\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "181c4f90-15f9-11ea-a3e1-b14356404360",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:29:37.286Z",
-      "version": 4,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzM2LDFd",
       "attributes": {
         "title": "Container Execution Metrics (seconds)",
         "visState": "{\"title\":\"Container Execution Metrics (seconds)\",\"type\":\"metric\",\"params\":{\"fontSize\":\"18\",\"handleNoResults\":true,\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":20}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Containers Executed\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.wall_time\",\"customLabel\":\"min duration\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.wall_time\",\"percents\":[50],\"customLabel\":\"duration\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.wall_time\",\"customLabel\":\"mean duration\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.wall_time\",\"customLabel\":\"max duration\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"std_dev\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.wall_time\",\"customLabel\":\"std_dev\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "7d7aeef0-15f9-11ea-a3e1-b14356404360",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:30:04.403Z",
-      "version": 4,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzM3LDFd",
       "attributes": {
         "title": "Container Execution Time Distribution",
         "visState": "{\"title\":\"Container Execution Time Distribution\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.metrics.usage_stats.wall_time\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}],\"type\":\"histogram\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.wall_time\",\"interval\":60,\"extended_bounds\":{},\"customLabel\":\"container execution duration (seconds)\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "15932c50-15fc-11ea-a3e1-b14356404360",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:38:22.613Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzM4LDFd",
       "attributes": {
         "title": "Container Total CPU Usage Distribution",
         "visState": "{\"title\":\"Container Total CPU Usage Distribution\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.cmd_duration\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}],\"type\":\"histogram\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"interval\":60000000000,\"extended_bounds\":{},\"customLabel\":\"total CPU usage (seconds)\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "541a4b60-15fd-11ea-a3e1-b14356404360",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:47:57.080Z",
-      "version": 2,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzM5LDFd",
       "attributes": {
         "title": "Container Memory Usage Distribution",
         "visState": "{\"title\":\"Container Memory Usage Distribution\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"job.job_info.cmd_duration\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}],\"type\":\"histogram\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"interval\":536870912,\"extended_bounds\":{},\"customLabel\":\"container memory usage\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "5433f870-15fe-11ea-a3e1-b14356404360",
       "type": "visualization",
-      "updated_at": "2019-12-03T18:54:26.679Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzQwLDFd",
       "attributes": {
         "title": "Mean Job Execution Time By Job Type",
         "visState": "{\"title\":\"Mean Job Execution Time By Job Type\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":false,\"truncate\":200},\"position\":\"left\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average job.job_info.duration\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":true,\"rotate\":75,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"bottom\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average job.job_info.duration\"},\"type\":\"value\"}],\"type\":\"histogram\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"job.job_info.duration\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"job_type.keyword\",\"size\":100,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "4e4b5a90-5ad3-11e7-8e6a-cbf606444333",
       "type": "search",
-      "updated_at": "2019-12-03T17:11:07.931Z",
-      "version": 2,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:13.659Z",
+      "version": "WzQxLDFd",
       "attributes": {
         "title": "job_info",
         "description": "",
@@ -524,43 +1093,44 @@
           "_source"
         ],
         "sort": [
-          "@timestamp",
-          "desc"
+          [
+            "@timestamp",
+            "desc"
+          ]
         ],
         "version": 1,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"index\": \"75800890-8b5b-11e8-9fd0-236fca1cd40c\",\n  \"highlightAll\": true,\n  \"version\": true,\n  \"query\": {\n    \"query\": {\n      \"query_string\": {\n        \"query\": \"type.keyword:job_info\",\n        \"analyze_wildcard\": true\n      }\n    },\n    \"language\": \"lucene\"\n  },\n  \"filter\": []\n}"
+          "searchSourceJSON": "{\"highlightAll\":true,\"version\":true,\"query\":{\"query\":{\"query_string\":{\"query\":\"type.keyword:job_info\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
         }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "75800890-8b5b-11e8-9fd0-236fca1cd40c"
+        }
+      ],
+      "migrationVersion": {
+        "search": "7.9.3"
       }
     },
     {
       "id": "75800890-8b5b-11e8-9fd0-236fca1cd40c",
       "type": "index-pattern",
-      "updated_at": "2019-12-03T17:00:58.125Z",
-      "version": 22,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T22:29:19.615Z",
+      "version": "WzI0NTMsMV0=",
       "attributes": {
         "title": "logstash-*",
         "timeFieldName": "@timestamp",
-        "fields": "[{\"name\":\"@timestamp\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"@version\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_score\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_source\",\"type\":\"_source\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"geoip.ip\",\"type\":\"ip\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"geoip.latitude\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"geoip.location\",\"type\":\"geo_point\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"geoip.longitude\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.container_image_name\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.container_image_name.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.container_image_url\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.container_image_url.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.delivery_info.exchange\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.delivery_info.exchange.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.delivery_info.priority\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.delivery_info.redelivered\",\"type\":\"boolean\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.delivery_info.routing_key\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.delivery_info.routing_key.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.cmd_duration\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.cmd_end\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.cmd_start\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.context_file\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.context_file.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.datasets_cfg_file\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.datasets_cfg_file.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.dedup\",\"type\":\"boolean\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.duration\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.execute_node\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.execute_node.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.architecture\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.architecture.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.domain\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.domain.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ec2_instance_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ec2_instance_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ec2_instance_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ec2_instance_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ec2_placement_availability_zone\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ec2_placement_availability_zone.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.fqdn\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.fqdn.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.hardwaremodel\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.hardwaremodel.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.hostname\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.hostname.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.hysds_execute_node\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.hysds_execute_node.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.hysds_public_ip\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.hysds_public_ip.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ipaddress\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ipaddress.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ipaddress_eth0\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ipaddress_eth0.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.is_virtual\",\"type\":\"boolean\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.memoryfree\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.memoryfree.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.memorysize\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.memorysize.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.operatingsystem\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.operatingsystem.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.operatingsystemrelease\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.operatingsystemrelease.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.osfamily\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.osfamily.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.physicalprocessorcount\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.processorcount\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.swapfree\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.swapfree.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.swapsize\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.swapsize.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.uptime\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.uptime.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.virtual\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.virtual.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_dir\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_dir.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_payload.job_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_payload.job_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_payload.payload_task_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_payload.payload_task_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_queue\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_queue.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_url\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_url.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.duration\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.path\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.inputs_localized.path.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.time_end\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.time_start\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.transfer_rate\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.url\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.inputs_localized.url.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.job_dir_size\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.availability_time\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.processing_latency\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.processing_start_time\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.product_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.product_provenance.product_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.total_latency\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.browse_urls\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.browse_urls.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.dataset\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.dataset.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.dataset_level\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.dataset_level.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.dataset_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.dataset_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.disk_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.duration\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.index.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.ipath\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.ipath.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.path\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.path.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.system_version\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.system_version.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.time_end\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.time_start\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.transfer_rate\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.urls\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.urls.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.major\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.op\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.op.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.value\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.major\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.op\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.op.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.value\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.percpu_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_kernelmode\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_usermode\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.hugetlb_stats.1GB.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.hugetlb_stats.2MB.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.cache\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_tcp_usage.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_tcp_usage.limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_usage.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_usage.limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.active_anon\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.active_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.cache\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.hierarchical_memory_limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.hierarchical_memsw_limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.inactive_anon\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.inactive_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.mapped_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgfault\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgmajfault\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgpgin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgpgout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.rss\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.rss_huge\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.swap\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_active_anon\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_active_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_cache\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_inactive_anon\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_inactive_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_mapped_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgfault\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgmajfault\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgpgin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgpgout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_rss\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_rss_huge\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_swap\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_unevictable\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.unevictable\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.max_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.pids_stats.current\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.sys_cpu_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.user_cpu_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.wall_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.payload_hash\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.payload_hash.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.pid\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.public_ip\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.public_ip.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.soft_time_limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.status\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.stderr\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.stderr.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.stdout\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.stdout.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.time_end\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.time_limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.time_queued\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.time_start\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.name\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.name.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.priority\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.tag\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.tag.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.task_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.task_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.cpu\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.device\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.all.device.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.fs_opts\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.all.fs_opts.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.fs_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.all.fs_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.mount_point\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.all.mount_point.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.device\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.data.device.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.fs_opts\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.data.fs_opts.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.fs_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.data.fs_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.mount_point\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.data.mount_point.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.device\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.root.device.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.fs_opts\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.root.fs_opts.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.fs_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.root.fs_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.mount_point\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.root.mount_point.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.busy_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.read_bytes\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.read_count\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.read_merged_count\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.read_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.write_bytes\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.write_count\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.write_merged_count\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.write_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.host\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.host.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.host_up\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.active\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.available\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.buffers\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.cached\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.inactive\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.shared\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.slab\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.bytes_recv\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.bytes_sent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.dropin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.dropout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.errin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.errout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.packets_recv\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.packets_sent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.per_cpu\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.sin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.sout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"input_localized\",\"type\":\"number\",\"count\":0,\"scripted\":true,\"script\":\"if (doc['job.job_info.metrics.inputs_localized.disk_usage'].size()==0 || doc['job.job_info.metrics.inputs_localized.disk_usage'].value==0) {return 0;} return 1;\",\"lang\":\"painless\",\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"product_staged\",\"type\":\"number\",\"count\":0,\"scripted\":true,\"script\":\"if (doc['job.job_info.metrics.products_staged.disk_usage'].size()==0 || doc['job.job_info.metrics.products_staged.disk_usage'].value==0) {return 0;} return 1;\",\"lang\":\"painless\",\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false}]",
-        "fieldFormatMap": "{\"job.job_info.metrics.inputs_localized.disk_usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.products_staged.disk_usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.job_dir_size\":{\"id\":\"bytes\"},\"job.job_info.cmd_duration\":{\"id\":\"duration\",\"params\":{\"outputFormat\":\"asSeconds\"}},\"job.job_info.duration\":{\"id\":\"duration\",\"params\":{\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.inputs_localized.duration\":{\"id\":\"duration\",\"params\":{\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.products_staged.duration\":{\"id\":\"duration\",\"params\":{\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.wall_time\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.user_cpu_time\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.sys_cpu_time\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.percpu_usage\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_kernelmode\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_usermode\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.cache\":{\"id\":\"bytes\"},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.max_usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.usage\":{\"id\":\"bytes\"}}"
-      }
-    },
-    {
-      "id": "cb40a460-5ad3-11e7-8e6a-cbf606444333",
-      "type": "dashboard",
-      "updated_at": "2019-12-03T18:57:10.533Z",
-      "version": 6,
-      "attributes": {
-        "title": "Job Metrics",
-        "hits": 0,
-        "description": "",
-        "panelsJSON": "[{\"gridData\":{\"x\":0,\"y\":0,\"w\":48,\"h\":15,\"i\":\"1\"},\"id\":\"acb6f440-5ad3-11e7-8e6a-cbf606444333\",\"panelIndex\":\"1\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":15,\"w\":16,\"h\":25,\"i\":\"2\"},\"id\":\"38ea3850-5ad4-11e7-8e6a-cbf606444333\",\"panelIndex\":\"2\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":16,\"y\":15,\"w\":16,\"h\":25,\"i\":\"3\"},\"id\":\"b06f4be0-5ad4-11e7-8e6a-cbf606444333\",\"panelIndex\":\"3\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":32,\"y\":15,\"w\":16,\"h\":25,\"i\":\"4\"},\"id\":\"2f467fa0-5ad6-11e7-8e6a-cbf606444333\",\"panelIndex\":\"4\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":true}},\"gridData\":{\"x\":23,\"y\":40,\"w\":25,\"h\":25,\"i\":\"5\"},\"id\":\"f31a3920-5ad7-11e7-8e6a-cbf606444333\",\"panelIndex\":\"5\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":64,\"w\":23,\"h\":26,\"i\":\"6\"},\"id\":\"8a425c10-5ad8-11e7-8e6a-cbf606444333\",\"panelIndex\":\"6\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":23,\"y\":65,\"w\":25,\"h\":25,\"i\":\"7\"},\"id\":\"2cf9f030-5ad9-11e7-8e6a-cbf606444333\",\"panelIndex\":\"7\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":90,\"w\":48,\"h\":11,\"i\":\"8\"},\"id\":\"ff3e1030-5ad9-11e7-8e6a-cbf606444333\",\"panelIndex\":\"8\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"x\":0,\"y\":101,\"w\":48,\"h\":15,\"i\":\"9\"},\"id\":\"e8c21a90-5b47-11e7-9160-a9831305fdae\",\"panelIndex\":\"9\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":196,\"w\":48,\"h\":15,\"i\":\"10\"},\"id\":\"22296d50-5b49-11e7-9160-a9831305fdae\",\"panelIndex\":\"10\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":211,\"w\":47,\"h\":12,\"i\":\"11\"},\"id\":\"ff5c3fc0-5b4b-11e7-9160-a9831305fdae\",\"panelIndex\":\"11\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":223,\"w\":48,\"h\":15,\"i\":\"12\"},\"id\":\"0ec46c60-5b4e-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"12\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":252,\"w\":48,\"h\":15,\"i\":\"13\"},\"id\":\"96a964f0-5b4e-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"13\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":238,\"w\":48,\"h\":14,\"i\":\"14\"},\"id\":\"5d7772b0-5b50-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"14\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":267,\"w\":47,\"h\":8,\"i\":\"15\"},\"id\":\"d56a3c30-5b50-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"15\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":275,\"w\":48,\"h\":15,\"i\":\"16\"},\"id\":\"249ee080-5b51-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"16\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":290,\"w\":48,\"h\":15,\"i\":\"17\"},\"id\":\"3e637200-5b52-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"17\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":305,\"w\":48,\"h\":12,\"i\":\"18\"},\"id\":\"7cc6f8f0-5b52-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"18\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":317,\"w\":48,\"h\":15,\"i\":\"19\"},\"id\":\"96722b80-5b52-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"19\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":332,\"w\":48,\"h\":11,\"i\":\"20\"},\"id\":\"b2fdc1b0-5b52-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"20\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":358,\"w\":48,\"h\":8,\"i\":\"21\"},\"id\":\"d3477150-5b52-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"21\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":366,\"w\":48,\"h\":15,\"i\":\"22\"},\"id\":\"e8273920-5b52-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"22\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"gridData\":{\"x\":0,\"y\":343,\"w\":48,\"h\":15,\"i\":\"23\"},\"id\":\"4fa3fd90-5b53-11e7-9c6a-6d89ce62415a\",\"panelIndex\":\"23\",\"type\":\"visualization\",\"version\":\"6.3.1\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":142,\"w\":47,\"h\":10,\"i\":\"24\"},\"id\":\"af7c6180-15f0-11ea-a3e1-b14356404360\",\"panelIndex\":\"24\",\"type\":\"visualization\",\"version\":\"6.4.2\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":168,\"w\":47,\"h\":10,\"i\":\"25\"},\"id\":\"897ccdd0-15f5-11ea-a3e1-b14356404360\",\"panelIndex\":\"25\",\"type\":\"visualization\",\"version\":\"6.4.2\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":116,\"w\":48,\"h\":9,\"i\":\"26\"},\"id\":\"181c4f90-15f9-11ea-a3e1-b14356404360\",\"panelIndex\":\"26\",\"type\":\"visualization\",\"version\":\"6.4.2\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"x\":0,\"y\":125,\"w\":48,\"h\":17,\"i\":\"27\"},\"id\":\"7d7aeef0-15f9-11ea-a3e1-b14356404360\",\"panelIndex\":\"27\",\"type\":\"visualization\",\"version\":\"6.4.2\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"x\":0,\"y\":152,\"w\":48,\"h\":16,\"i\":\"28\"},\"id\":\"15932c50-15fc-11ea-a3e1-b14356404360\",\"panelIndex\":\"28\",\"type\":\"visualization\",\"version\":\"6.4.2\"},{\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"gridData\":{\"x\":0,\"y\":178,\"w\":48,\"h\":18,\"i\":\"29\"},\"id\":\"541a4b60-15fd-11ea-a3e1-b14356404360\",\"panelIndex\":\"29\",\"type\":\"visualization\",\"version\":\"6.4.2\"},{\"gridData\":{\"x\":0,\"y\":40,\"w\":23,\"h\":24,\"i\":\"30\"},\"version\":\"6.4.2\",\"panelIndex\":\"30\",\"type\":\"visualization\",\"id\":\"5433f870-15fe-11ea-a3e1-b14356404360\",\"embeddableConfig\":{}}]",
-        "optionsJSON": "{\"darkTheme\":false,\"useMargins\":false}",
-        "version": 1,
-        "timeRestore": false,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"default_field\":\"*\",\"query\":\"*\"}}}}"
-        }
+        "fields": "[{\"count\":0,\"name\":\"@timestamp\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"@version\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_index\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_score\",\"type\":\"number\",\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_source\",\"type\":\"_source\",\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"geoip.ip\",\"type\":\"ip\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"geoip.latitude\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"geoip.location\",\"type\":\"geo_point\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"geoip.longitude\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.container_image_name\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.container_image_name.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.container_image_url\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.container_image_url.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.delivery_info.exchange\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.delivery_info.exchange.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.delivery_info.priority\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.delivery_info.redelivered\",\"type\":\"boolean\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.delivery_info.routing_key\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.delivery_info.routing_key.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.cmd_duration\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.cmd_end\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.cmd_start\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.context_file\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.context_file.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.datasets_cfg_file\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.datasets_cfg_file.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.dedup\",\"type\":\"boolean\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.duration\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.execute_node\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.execute_node.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.architecture\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.architecture.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.domain\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.domain.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ec2_instance_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ec2_instance_id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ec2_instance_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ec2_instance_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ec2_placement_availability_zone\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ec2_placement_availability_zone.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.fqdn\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.fqdn.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.hardwaremodel\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.hardwaremodel.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.hostname\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.hostname.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.hysds_execute_node\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.hysds_execute_node.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.hysds_public_ip\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.hysds_public_ip.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ipaddress\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ipaddress.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ipaddress_eth0\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ipaddress_eth0.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.is_virtual\",\"type\":\"boolean\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.memoryfree\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.memoryfree.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.memorysize\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.memorysize.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.operatingsystem\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.operatingsystem.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.operatingsystemrelease\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.operatingsystemrelease.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.osfamily\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.osfamily.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.physicalprocessorcount\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.processorcount\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.swapfree\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.swapfree.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.swapsize\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.swapsize.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.uptime\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.uptime.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.virtual\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.virtual.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_dir\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_dir.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_payload.job_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_payload.job_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_payload.payload_task_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_payload.payload_task_id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_queue\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_queue.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_url\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_url.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.duration\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.path\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.path.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.time_end\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.time_start\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.transfer_rate\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.url\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.url.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.job_dir_size\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.availability_time\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.processing_latency\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.processing_start_time\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.product_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.product_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.total_latency\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.browse_urls\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.browse_urls.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset_level\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset_level.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.disk_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.duration\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.index\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.index.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.ipath\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.ipath.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.path\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.path.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.system_version\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.system_version.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.time_end\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.time_start\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.transfer_rate\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.urls\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.urls.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.major\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.op\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.op.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.value\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.major\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.op\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.op.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.value\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.percpu_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_kernelmode\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_usermode\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.hugetlb_stats.1GB.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.hugetlb_stats.2MB.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.cache\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_tcp_usage.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_tcp_usage.limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_usage.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_usage.limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.active_anon\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.active_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.cache\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.hierarchical_memory_limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.hierarchical_memsw_limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.inactive_anon\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.inactive_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.mapped_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgfault\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgmajfault\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgpgin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgpgout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.rss\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.rss_huge\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.swap\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_active_anon\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_active_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_cache\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_inactive_anon\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_inactive_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_mapped_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgfault\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgmajfault\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgpgin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgpgout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_rss\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_rss_huge\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_swap\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_unevictable\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.unevictable\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.max_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.pids_stats.current\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.sys_cpu_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.user_cpu_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.wall_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.payload_hash\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.payload_hash.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.pid\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.public_ip\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.public_ip.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.soft_time_limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.status\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.stderr\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.stderr.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.stdout\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.stdout.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.time_end\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.time_limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.time_queued\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.time_start\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.name\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.name.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.priority\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.tag\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.tag.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.task_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.task_id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.cpu\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.device\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.all.device.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.fs_opts\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.all.fs_opts.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.fs_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.all.fs_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.mount_point\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.all.mount_point.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.device\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.data.device.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.fs_opts\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.data.fs_opts.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.fs_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.data.fs_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.mount_point\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.data.mount_point.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.device\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.root.device.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.fs_opts\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.root.fs_opts.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.fs_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.root.fs_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.mount_point\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.root.mount_point.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.busy_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.read_bytes\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.read_count\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.read_merged_count\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.read_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.write_bytes\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.write_count\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.write_merged_count\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.write_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.host\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.host.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.host_up\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.active\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.available\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.buffers\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.cached\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.inactive\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.shared\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.slab\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.bytes_recv\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.bytes_sent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.dropin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.dropout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.errin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.errout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.packets_recv\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.packets_sent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.per_cpu\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.sin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.sout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]",
+        "fieldFormatMap": "{\"job.job_info.cmd_duration\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"outputFormat\":\"asSeconds\"}},\"job.job_info.duration\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.inputs_localized.disk_usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.inputs_localized.duration\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.job_dir_size\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.products_staged.disk_usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.products_staged.duration\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.percpu_usage\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_kernelmode\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_usermode\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.cache\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.max_usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.sys_cpu_time\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.user_cpu_time\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.wall_time\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.inputs_localized.transfer_rate\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.products_staged.transfer_rate\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}}}"
+      },
+      "references": [],
+      "migrationVersion": {
+        "index-pattern": "7.6.0"
       }
     }
   ]

--- a/sdscli/adapters/hysds/files/kibana_dashboard_import/sdswatch-dashboards.json
+++ b/sdscli/adapters/hysds/files/kibana_dashboard_import/sdswatch-dashboards.json
@@ -1,16 +1,19 @@
 {
-  "version": "7.1.1",
+  "version": "7.10.2",
   "objects": [
     {
       "id": "482537f0-7d4b-11eb-9963-0336cf2a3b43",
       "type": "dashboard",
-      "updated_at": "2021-03-05T02:38:45.481Z",
-      "version": "WzI5LDJd",
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:17.673Z",
+      "version": "Wzg2LDFd",
       "attributes": {
         "title": "Minimal OPS UI",
         "hits": 0,
         "description": "Minimal example of an OPS UI",
-        "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":0,\"w\":48,\"h\":17,\"i\":\"1\"},\"panelIndex\":\"1\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":17,\"w\":48,\"h\":24,\"i\":\"2\"},\"panelIndex\":\"2\",\"version\":\"7.1.1\",\"panelRefName\":\"panel_1\"}]",
+        "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":0,\"w\":48,\"h\":17,\"i\":\"1\"},\"panelIndex\":\"1\",\"version\":\"7.3.0\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":17,\"w\":48,\"h\":24,\"i\":\"2\"},\"panelIndex\":\"2\",\"version\":\"7.3.0\",\"panelRefName\":\"panel_1\"}]",
         "optionsJSON": "{\"hidePanelTitles\":false,\"useMargins\":true}",
         "version": 1,
         "timeRestore": false,
@@ -31,14 +34,17 @@
         }
       ],
       "migrationVersion": {
-        "dashboard": "7.0.0"
+        "dashboard": "7.9.3"
       }
     },
     {
       "id": "a4ef7320-7d4a-11eb-9963-0336cf2a3b43",
       "type": "visualization",
-      "updated_at": "2021-03-05T02:36:01.512Z",
-      "version": "WzI3LDJd",
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:17.673Z",
+      "version": "Wzg3LDFd",
       "attributes": {
         "title": "Systemd Service Status",
         "visState": "{\"title\":\"Systemd Service Status\",\"type\":\"table\",\"params\":{\"perPage\":100,\"showPartialRows\":false,\"showMetricsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"sdswatch_timestamp\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"systemd.ActiveState.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"6\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"systemd.SubState.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"systemd.ActiveStateTimestamp.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"host.keyword\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"_key\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"systemd.service.keyword\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"_key\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
@@ -58,14 +64,17 @@
         }
       ],
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "0ccef100-7d4b-11eb-9963-0336cf2a3b43",
       "type": "visualization",
-      "updated_at": "2021-03-05T00:49:38.329Z",
-      "version": "WzIzLDJd",
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:17.673Z",
+      "version": "Wzg4LDFd",
       "attributes": {
         "title": "Supervisord Service Status",
         "visState": "{\"title\":\"Supervisord Service Status\",\"type\":\"table\",\"params\":{\"perPage\":100,\"showPartialRows\":false,\"showMetricsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"sdswatch_timestamp\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"host.keyword\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"_key\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"supervisord.service.keyword\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"_key\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"supervisord.status.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"sdswatch_timestamp\",\"sortOrder\":\"desc\"}},{\"id\":\"5\",\"enabled\":true,\"type\":\"top_hits\",\"schema\":\"metric\",\"params\":{\"field\":\"supervisord.uptime.keyword\",\"aggregate\":\"concat\",\"size\":1,\"sortField\":\"@timestamp\",\"sortOrder\":\"desc\"}}]}",
@@ -85,14 +94,17 @@
         }
       ],
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "2089dd50-7d4a-11eb-9963-0336cf2a3b43",
       "type": "search",
-      "updated_at": "2021-03-05T00:31:29.189Z",
-      "version": "WzEzLDJd",
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:17.673Z",
+      "version": "Wzg5LDFd",
       "attributes": {
         "title": "Search: systemd",
         "description": "",
@@ -101,8 +113,10 @@
           "_source"
         ],
         "sort": [
-          "@timestamp",
-          "desc"
+          [
+            "@timestamp",
+            "desc"
+          ]
         ],
         "version": 1,
         "kibanaSavedObjectMeta": {
@@ -122,14 +136,17 @@
         }
       ],
       "migrationVersion": {
-        "search": "7.0.0"
+        "search": "7.9.3"
       }
     },
     {
       "id": "2ea8d300-7d4a-11eb-9963-0336cf2a3b43",
       "type": "search",
-      "updated_at": "2021-03-05T00:31:52.880Z",
-      "version": "WzE0LDJd",
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:17.673Z",
+      "version": "WzkwLDFd",
       "attributes": {
         "title": "Search: supervisord",
         "description": "",
@@ -138,8 +155,10 @@
           "_source"
         ],
         "sort": [
-          "@timestamp",
-          "desc"
+          [
+            "@timestamp",
+            "desc"
+          ]
         ],
         "version": 1,
         "kibanaSavedObjectMeta": {
@@ -159,14 +178,17 @@
         }
       ],
       "migrationVersion": {
-        "search": "7.0.0"
+        "search": "7.9.3"
       }
     },
     {
       "id": "684cf7c0-7d37-11eb-9ca4-d9758905c91a",
       "type": "index-pattern",
-      "updated_at": "2021-03-05T00:30:59.254Z",
-      "version": "WzEyLDJd",
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:17.673Z",
+      "version": "WzkxLDFd",
       "attributes": {
         "title": "sdswatch-*",
         "timeFieldName": "@timestamp",
@@ -174,7 +196,7 @@
       },
       "references": [],
       "migrationVersion": {
-        "index-pattern": "6.5.0"
+        "index-pattern": "7.6.0"
       }
     }
   ]

--- a/sdscli/adapters/hysds/files/kibana_dashboard_import/worker-dashboards.json
+++ b/sdscli/adapters/hysds/files/kibana_dashboard_import/worker-dashboards.json
@@ -1,657 +1,1370 @@
 {
-  "version": "6.4.2",
+  "version": "7.10.2",
   "objects": [
+    {
+      "id": "5e0abbd0-5abd-11e7-a451-0fe7e85b0f7a",
+      "type": "dashboard",
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzgzLDFd",
+      "attributes": {
+        "title": "Worker Metrics",
+        "hits": 0,
+        "description": "",
+        "panelsJSON": "[{\"panelIndex\":\"1\",\"panelRefName\":\"panel_0\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":0,\"w\":48,\"h\":12,\"i\":\"1\"},\"embeddableConfig\":{}},{\"panelIndex\":\"2\",\"panelRefName\":\"panel_1\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":12,\"w\":48,\"h\":12,\"i\":\"2\"},\"embeddableConfig\":{}},{\"panelIndex\":\"3\",\"panelRefName\":\"panel_2\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":24,\"w\":16,\"h\":12,\"i\":\"3\"},\"embeddableConfig\":{}},{\"panelIndex\":\"4\",\"panelRefName\":\"panel_3\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":24,\"w\":16,\"h\":12,\"i\":\"4\"},\"embeddableConfig\":{}},{\"panelIndex\":\"5\",\"panelRefName\":\"panel_4\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":24,\"w\":16,\"h\":12,\"i\":\"5\"},\"embeddableConfig\":{}},{\"panelIndex\":\"6\",\"panelRefName\":\"panel_5\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":36,\"w\":16,\"h\":12,\"i\":\"6\"},\"embeddableConfig\":{}},{\"panelIndex\":\"7\",\"panelRefName\":\"panel_6\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":36,\"w\":16,\"h\":12,\"i\":\"7\"},\"embeddableConfig\":{}},{\"panelIndex\":\"8\",\"panelRefName\":\"panel_7\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":36,\"w\":16,\"h\":12,\"i\":\"8\"},\"embeddableConfig\":{}},{\"panelIndex\":\"9\",\"panelRefName\":\"panel_8\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":48,\"w\":16,\"h\":12,\"i\":\"9\"},\"embeddableConfig\":{}},{\"panelIndex\":\"10\",\"panelRefName\":\"panel_9\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":48,\"w\":16,\"h\":12,\"i\":\"10\"},\"embeddableConfig\":{}},{\"panelIndex\":\"11\",\"panelRefName\":\"panel_10\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":48,\"w\":16,\"h\":12,\"i\":\"11\"},\"embeddableConfig\":{}},{\"panelIndex\":\"12\",\"panelRefName\":\"panel_11\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":60,\"w\":16,\"h\":12,\"i\":\"12\"},\"embeddableConfig\":{}},{\"panelIndex\":\"13\",\"panelRefName\":\"panel_12\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":60,\"w\":16,\"h\":12,\"i\":\"13\"},\"embeddableConfig\":{}},{\"panelIndex\":\"14\",\"panelRefName\":\"panel_13\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":60,\"w\":16,\"h\":12,\"i\":\"14\"},\"embeddableConfig\":{}},{\"panelIndex\":\"15\",\"panelRefName\":\"panel_14\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":72,\"w\":16,\"h\":12,\"i\":\"15\"},\"embeddableConfig\":{}},{\"panelIndex\":\"16\",\"panelRefName\":\"panel_15\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":72,\"w\":16,\"h\":12,\"i\":\"16\"},\"embeddableConfig\":{}},{\"panelIndex\":\"17\",\"panelRefName\":\"panel_16\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":72,\"w\":16,\"h\":12,\"i\":\"17\"},\"embeddableConfig\":{}},{\"panelIndex\":\"18\",\"panelRefName\":\"panel_17\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":84,\"w\":16,\"h\":12,\"i\":\"18\"},\"embeddableConfig\":{}},{\"panelIndex\":\"19\",\"panelRefName\":\"panel_18\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":84,\"w\":16,\"h\":12,\"i\":\"19\"},\"embeddableConfig\":{}},{\"panelIndex\":\"20\",\"panelRefName\":\"panel_19\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":84,\"w\":16,\"h\":12,\"i\":\"20\"},\"embeddableConfig\":{}},{\"panelIndex\":\"21\",\"panelRefName\":\"panel_20\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":108,\"w\":16,\"h\":12,\"i\":\"21\"},\"embeddableConfig\":{}},{\"panelIndex\":\"23\",\"panelRefName\":\"panel_21\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":108,\"w\":16,\"h\":12,\"i\":\"23\"},\"embeddableConfig\":{}},{\"panelIndex\":\"24\",\"panelRefName\":\"panel_22\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":108,\"w\":16,\"h\":12,\"i\":\"24\"},\"embeddableConfig\":{}},{\"panelIndex\":\"25\",\"panelRefName\":\"panel_23\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":96,\"w\":16,\"h\":12,\"i\":\"25\"},\"embeddableConfig\":{}},{\"panelIndex\":\"26\",\"panelRefName\":\"panel_24\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":96,\"w\":16,\"h\":12,\"i\":\"26\"},\"embeddableConfig\":{}},{\"panelIndex\":\"27\",\"panelRefName\":\"panel_25\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":96,\"w\":16,\"h\":12,\"i\":\"27\"},\"embeddableConfig\":{}},{\"panelIndex\":\"28\",\"panelRefName\":\"panel_26\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":120,\"w\":16,\"h\":12,\"i\":\"28\"},\"embeddableConfig\":{}},{\"panelIndex\":\"29\",\"panelRefName\":\"panel_27\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":120,\"w\":16,\"h\":12,\"i\":\"29\"},\"embeddableConfig\":{}},{\"panelIndex\":\"30\",\"panelRefName\":\"panel_28\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":120,\"w\":16,\"h\":12,\"i\":\"30\"},\"embeddableConfig\":{}},{\"panelIndex\":\"31\",\"panelRefName\":\"panel_29\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":132,\"w\":16,\"h\":12,\"i\":\"31\"},\"embeddableConfig\":{}},{\"panelIndex\":\"32\",\"panelRefName\":\"panel_30\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":132,\"w\":16,\"h\":12,\"i\":\"32\"},\"embeddableConfig\":{}},{\"panelIndex\":\"33\",\"panelRefName\":\"panel_31\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":132,\"w\":16,\"h\":12,\"i\":\"33\"},\"embeddableConfig\":{}},{\"panelIndex\":\"34\",\"panelRefName\":\"panel_32\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":144,\"w\":16,\"h\":12,\"i\":\"34\"},\"embeddableConfig\":{}},{\"panelIndex\":\"35\",\"panelRefName\":\"panel_33\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":144,\"w\":16,\"h\":12,\"i\":\"35\"},\"embeddableConfig\":{}},{\"panelIndex\":\"36\",\"panelRefName\":\"panel_34\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":144,\"w\":16,\"h\":12,\"i\":\"36\"},\"embeddableConfig\":{}},{\"panelIndex\":\"37\",\"panelRefName\":\"panel_35\",\"version\":\"7.3.0\",\"gridData\":{\"x\":0,\"y\":156,\"w\":16,\"h\":12,\"i\":\"37\"},\"embeddableConfig\":{}},{\"panelIndex\":\"38\",\"panelRefName\":\"panel_36\",\"version\":\"7.3.0\",\"gridData\":{\"x\":16,\"y\":156,\"w\":16,\"h\":12,\"i\":\"38\"},\"embeddableConfig\":{}},{\"panelIndex\":\"39\",\"panelRefName\":\"panel_37\",\"version\":\"7.3.0\",\"gridData\":{\"x\":32,\"y\":156,\"w\":16,\"h\":12,\"i\":\"39\"},\"embeddableConfig\":{}}]",
+        "optionsJSON": "{\"darkTheme\":true}",
+        "version": 1,
+        "timeRestore": false,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"*\",\"language\":\"lucene\"}}"
+        }
+      },
+      "references": [
+        {
+          "name": "panel_0",
+          "type": "visualization",
+          "id": "9da63870-5abb-11e7-a451-0fe7e85b0f7a"
+        },
+        {
+          "name": "panel_1",
+          "type": "visualization",
+          "id": "eab7a740-5abe-11e7-a451-0fe7e85b0f7a"
+        },
+        {
+          "name": "panel_2",
+          "type": "visualization",
+          "id": "f8a84480-5abf-11e7-a451-0fe7e85b0f7a"
+        },
+        {
+          "name": "panel_3",
+          "type": "visualization",
+          "id": "51b18aa0-5ac0-11e7-a451-0fe7e85b0f7a"
+        },
+        {
+          "name": "panel_4",
+          "type": "visualization",
+          "id": "61d1f5a0-5ac0-11e7-a451-0fe7e85b0f7a"
+        },
+        {
+          "name": "panel_5",
+          "type": "visualization",
+          "id": "74dc9d60-5ac2-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_6",
+          "type": "visualization",
+          "id": "8a967180-5ac2-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_7",
+          "type": "visualization",
+          "id": "9503d0e0-5ac2-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_8",
+          "type": "visualization",
+          "id": "fd9d7700-5ac2-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_9",
+          "type": "visualization",
+          "id": "0eceb5c0-5ac3-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_10",
+          "type": "visualization",
+          "id": "199fb8f0-5ac3-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_11",
+          "type": "visualization",
+          "id": "1de2ab10-5ac9-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_12",
+          "type": "visualization",
+          "id": "2bc24dd0-5ac9-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_13",
+          "type": "visualization",
+          "id": "3ae9d9e0-5ac9-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_14",
+          "type": "visualization",
+          "id": "1e200cc0-5aca-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_15",
+          "type": "visualization",
+          "id": "2a828560-5aca-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_16",
+          "type": "visualization",
+          "id": "358546f0-5aca-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_17",
+          "type": "visualization",
+          "id": "812f8c00-5aca-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_18",
+          "type": "visualization",
+          "id": "8c65b9a0-5aca-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_19",
+          "type": "visualization",
+          "id": "9a533f10-5aca-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_20",
+          "type": "visualization",
+          "id": "ecd575d0-5acc-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_21",
+          "type": "visualization",
+          "id": "d3163420-5ace-11e7-b04c-fb55ed28b6e9"
+        },
+        {
+          "name": "panel_22",
+          "type": "visualization",
+          "id": "c4d314a0-5ace-11e7-b04c-fb55ed28b6e9"
+        },
+        {
+          "name": "panel_23",
+          "type": "visualization",
+          "id": "0a2aaf80-5acb-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_24",
+          "type": "visualization",
+          "id": "20dd89a0-5acb-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_25",
+          "type": "visualization",
+          "id": "35bd5170-5acb-11e7-a8a3-37f88d4052ad"
+        },
+        {
+          "name": "panel_26",
+          "type": "visualization",
+          "id": "7d936030-5acf-11e7-b04c-fb55ed28b6e9"
+        },
+        {
+          "name": "panel_27",
+          "type": "visualization",
+          "id": "9724c930-5acf-11e7-b04c-fb55ed28b6e9"
+        },
+        {
+          "name": "panel_28",
+          "type": "visualization",
+          "id": "a55f8440-5acf-11e7-b04c-fb55ed28b6e9"
+        },
+        {
+          "name": "panel_29",
+          "type": "visualization",
+          "id": "cb080500-5acf-11e7-b04c-fb55ed28b6e9"
+        },
+        {
+          "name": "panel_30",
+          "type": "visualization",
+          "id": "daba9300-5acf-11e7-b04c-fb55ed28b6e9"
+        },
+        {
+          "name": "panel_31",
+          "type": "visualization",
+          "id": "bb2f9f80-5acf-11e7-b04c-fb55ed28b6e9"
+        },
+        {
+          "name": "panel_32",
+          "type": "visualization",
+          "id": "4c5541d0-5ad1-11e7-a812-bffabc6a4541"
+        },
+        {
+          "name": "panel_33",
+          "type": "visualization",
+          "id": "611e9b70-5ad1-11e7-a812-bffabc6a4541"
+        },
+        {
+          "name": "panel_34",
+          "type": "visualization",
+          "id": "6c86ae80-5ad1-11e7-a812-bffabc6a4541"
+        },
+        {
+          "name": "panel_35",
+          "type": "visualization",
+          "id": "8582b550-5ad1-11e7-a812-bffabc6a4541"
+        },
+        {
+          "name": "panel_36",
+          "type": "visualization",
+          "id": "923e9890-5ad1-11e7-a812-bffabc6a4541"
+        },
+        {
+          "name": "panel_37",
+          "type": "visualization",
+          "id": "a1611b90-5ad1-11e7-a812-bffabc6a4541"
+        }
+      ],
+      "migrationVersion": {
+        "dashboard": "7.9.3"
+      }
+    },
     {
       "id": "9da63870-5abb-11e7-a451-0fe7e85b0f7a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzQ0LDFd",
       "attributes": {
         "title": "Instance Heartbeats",
-        "visState": "{\"title\":\"Instance Heartbeats\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":true,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"host heartbeats\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\",\"defaultYExtents\":false,\"setYExtents\":false},\"show\":true,\"style\":{},\"title\":{\"text\":\"host heartbeats\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.host_up\",\"customLabel\":\"host heartbeats\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"custom\",\"customInterval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Instance Heartbeats\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":true,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"host heartbeats\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\",\"defaultYExtents\":false,\"setYExtents\":false},\"show\":true,\"style\":{},\"title\":{\"text\":\"host heartbeats\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.host_up\",\"customLabel\":\"host heartbeats\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"10m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "eab7a740-5abe-11e7-a451-0fe7e85b0f7a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzQ1LDFd",
       "attributes": {
         "title": "Instances",
         "visState": "{\"title\":\"Instances\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":200},\"position\":\"left\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"stats.host.keyword: Descending\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"right\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"normal\",\"show\":true,\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":true,\"rotate\":75,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"bottom\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"stats.host.keyword\",\"size\":1000,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "f8a84480-5abf-11e7-a451-0fe7e85b0f7a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzQ2LDFd",
       "attributes": {
         "title": "Min Instance CPU Utilization (percent)",
-        "visState": "{\"title\":\"Min Instance CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\",\"setYExtents\":true,\"max\":100,\"min\":0},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\",\"setYExtents\":true,\"max\":100,\"min\":0},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "51b18aa0-5ac0-11e7-a451-0fe7e85b0f7a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzQ3LDFd",
       "attributes": {
         "title": "Mean Instance CPU Utilization (percent)",
-        "visState": "{\"title\":\"Mean Instance CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\",\"setYExtents\":true,\"max\":100,\"min\":0},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\",\"setYExtents\":true,\"max\":100,\"min\":0},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "61d1f5a0-5ac0-11e7-a451-0fe7e85b0f7a",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzQ4LDFd",
       "attributes": {
         "title": "Max Instance CPU Utilization (percent)",
-        "visState": "{\"title\":\"Max Instance CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\",\"setYExtents\":true,\"max\":100,\"min\":0},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\",\"setYExtents\":true,\"max\":100,\"min\":0},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "74dc9d60-5ac2-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzQ5LDFd",
       "attributes": {
         "title": "Min Per Core CPU Utilization (percent)",
-        "visState": "{\"title\":\"Min Per Core CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.per_cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.per_cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.per_cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Per Core CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.per_cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.per_cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.per_cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "8a967180-5ac2-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzUwLDFd",
       "attributes": {
         "title": "Mean Per Core CPU Utilization (percent)",
-        "visState": "{\"title\":\"Mean Per Core CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.per_cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.per_cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.per_cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Per Core CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.per_cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.per_cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.per_cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "9503d0e0-5ac2-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzUxLDFd",
       "attributes": {
         "title": "Max Per Core CPU Utilization (percent)",
-        "visState": "{\"title\":\"Max Per Core CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.per_cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.per_cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.per_cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Per Core CPU Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.per_cpu\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.per_cpu\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.per_cpu\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "fd9d7700-5ac2-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzUyLDFd",
       "attributes": {
         "title": "Min Instance Memory Utilization (percent)",
-        "visState": "{\"title\":\"Min Instance Memory Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.memory.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.memory.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.memory.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance Memory Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.memory.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.memory.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.memory.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "0eceb5c0-5ac3-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzUzLDFd",
       "attributes": {
         "title": "Mean Instance Memory Utilization (percent)",
-        "visState": "{\"title\":\"Mean Instance Memory Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.memory.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.memory.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.memory.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance Memory Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.memory.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.memory.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.memory.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "199fb8f0-5ac3-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzU0LDFd",
       "attributes": {
         "title": "Max Instance Memory Utilization (percent)",
-        "visState": "{\"title\":\"Max Instance Memory Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.memory.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.memory.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.memory.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance Memory Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.memory.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.memory.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.memory.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "1de2ab10-5ac9-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzU1LDFd",
       "attributes": {
         "title": "Min Instance Swap Utilization (percent)",
-        "visState": "{\"title\":\"Min Instance Swap Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.swap.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.swap.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.swap.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance Swap Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.swap.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.swap.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.swap.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "2bc24dd0-5ac9-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzU2LDFd",
       "attributes": {
         "title": "Mean Instance Swap Utilization (percent)",
-        "visState": "{\"title\":\"Mean Instance Swap Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.swap.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.swap.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.swap.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance Swap Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.swap.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.swap.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.swap.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "3ae9d9e0-5ac9-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzU3LDFd",
       "attributes": {
         "title": "Max Instance Swap Utilization (percent)",
-        "visState": "{\"title\":\"Max Instance Swap Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.swap.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.swap.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.swap.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance Swap Utilization (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.swap.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.swap.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.swap.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "1e200cc0-5aca-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzU4LDFd",
       "attributes": {
         "title": "Min Instance Root Disk Usage (percent)",
-        "visState": "{\"title\":\"Min Instance Root Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk.root.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk.root.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.root.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance Root Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk.root.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk.root.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.root.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "2a828560-5aca-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzU5LDFd",
       "attributes": {
         "title": "Mean Instance Root Disk Usage (percent)",
-        "visState": "{\"title\":\"Mean Instance Root Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk.root.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk.root.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.root.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance Root Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk.root.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk.root.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.root.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "358546f0-5aca-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzYwLDFd",
       "attributes": {
         "title": "Max Instance Root Disk Usage (percent)",
-        "visState": "{\"title\":\"Max Instance Root Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk.root.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk.root.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.root.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance Root Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk.root.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk.root.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.root.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "812f8c00-5aca-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzYxLDFd",
       "attributes": {
         "title": "Min Instance Work/Data Disk Usage (percent)",
-        "visState": "{\"title\":\"Min Instance Work/Data Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk.data.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk.data.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.data.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance Work/Data Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk.data.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk.data.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.data.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "8c65b9a0-5aca-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzYyLDFd",
       "attributes": {
         "title": "Mean Instance Work/Data Disk Usage (percent)",
-        "visState": "{\"title\":\"Mean Instance Work/Data Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk.data.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk.data.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.data.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance Work/Data Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk.data.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk.data.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.data.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "9a533f10-5aca-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzYzLDFd",
       "attributes": {
         "title": "Max Instance Work/Data Disk Usage (percent)",
-        "visState": "{\"title\":\"Max Instance Work/Data Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk.data.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk.data.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.data.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance Work/Data Disk Usage (percent)\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per 10 minutes\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk.data.percent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"max\":100,\"min\":0,\"mode\":\"normal\",\"setYExtents\":true,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk.data.percent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk.data.percent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "ecd575d0-5acc-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzY0LDFd",
       "attributes": {
         "title": "Min Instance Disk I/O Bytes Read",
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customLabel\":\"\",\"field\":\"stats.disk_io.read_bytes\"},\"schema\":\"metric\",\"type\":\"min\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk_io.read_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk_io.read_bytes\"},\"type\":\"value\"}]},\"title\":\"Min Instance Disk I/O Bytes Read\",\"type\":\"histogram\"}",
+        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"customLabel\":\"\",\"field\":\"stats.disk_io.read_bytes\"},\"schema\":\"metric\",\"type\":\"min\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk_io.read_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk_io.read_bytes\"},\"type\":\"value\"}]},\"title\":\"Min Instance Disk I/O Bytes Read\",\"type\":\"histogram\"}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "d3163420-5ace-11e7-b04c-fb55ed28b6e9",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzY1LDFd",
       "attributes": {
         "title": "Max Instance Disk I/O Bytes Read",
-        "visState": "{\"title\":\"Max Instance Disk I/O Bytes Read\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk_io.read_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk_io.read_bytes\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.read_bytes\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance Disk I/O Bytes Read\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk_io.read_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk_io.read_bytes\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.read_bytes\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "c4d314a0-5ace-11e7-b04c-fb55ed28b6e9",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzY2LDFd",
       "attributes": {
         "title": "Mean Instance Disk I/O Bytes Read",
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"field\":\"stats.disk_io.read_bytes\"},\"schema\":\"metric\",\"type\":\"avg\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk_io.read_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk_io.read_bytes\"},\"type\":\"value\"}]},\"title\":\"Mean Instance Disk I/O Bytes Read\",\"type\":\"histogram\"}",
+        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"field\":\"stats.disk_io.read_bytes\"},\"schema\":\"metric\",\"type\":\"avg\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk_io.read_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk_io.read_bytes\"},\"type\":\"value\"}]},\"title\":\"Mean Instance Disk I/O Bytes Read\",\"type\":\"histogram\"}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "0a2aaf80-5acb-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzY3LDFd",
       "attributes": {
         "title": "Min Instance Disk I/O Reads",
-        "visState": "{\"title\":\"Min Instance Disk I/O Reads\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk_io.read_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk_io.read_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.read_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance Disk I/O Reads\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk_io.read_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk_io.read_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.read_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "20dd89a0-5acb-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzY4LDFd",
       "attributes": {
         "title": "Mean Instance Disk I/O Reads",
-        "visState": "{\"title\":\"Mean Instance Disk I/O Reads\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk_io.read_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk_io.read_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.read_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance Disk I/O Reads\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk_io.read_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk_io.read_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.read_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "35bd5170-5acb-11e7-a8a3-37f88d4052ad",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzY5LDFd",
       "attributes": {
         "title": "Max Instance Disk I/O Reads",
-        "visState": "{\"title\":\"Max Instance Disk I/O Reads\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk_io.read_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk_io.read_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.read_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance Disk I/O Reads\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk_io.read_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk_io.read_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.read_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "7d936030-5acf-11e7-b04c-fb55ed28b6e9",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzcwLDFd",
       "attributes": {
         "title": "Min Instance Disk I/O Writes",
-        "visState": "{\"title\":\"Min Instance Disk I/O Writes\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk_io.write_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk_io.write_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance Disk I/O Writes\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk_io.write_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk_io.write_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "9724c930-5acf-11e7-b04c-fb55ed28b6e9",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzcxLDFd",
       "attributes": {
         "title": "Mean Instance Disk I/O Writes",
-        "visState": "{\"title\":\"Mean Instance Disk I/O Writes\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk_io.write_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk_io.write_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance Disk I/O Writes\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk_io.write_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk_io.write_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "a55f8440-5acf-11e7-b04c-fb55ed28b6e9",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzcyLDFd",
       "attributes": {
         "title": "Max Instance Disk I/O Writes",
-        "visState": "{\"title\":\"Max Instance Disk I/O Writes\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk_io.write_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk_io.write_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance Disk I/O Writes\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk_io.write_count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk_io.write_count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "cb080500-5acf-11e7-b04c-fb55ed28b6e9",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzczLDFd",
       "attributes": {
         "title": "Mean Instance Disk I/O Bytes Written",
-        "visState": "{\"title\":\"Mean Instance Disk I/O Bytes Written\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk_io.write_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk_io.write_bytes\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_bytes\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance Disk I/O Bytes Written\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.disk_io.write_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.disk_io.write_bytes\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_bytes\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "daba9300-5acf-11e7-b04c-fb55ed28b6e9",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "Wzc0LDFd",
       "attributes": {
         "title": "Max Instance Disk I/O Bytes Written",
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"field\":\"stats.disk_io.read_bytes\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customInterval\":\"2h\",\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk_io.read_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk_io.read_bytes\"},\"type\":\"value\"}]},\"title\":\"Max Instance Disk I/O Bytes Written\",\"type\":\"histogram\"}",
+        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{\"field\":\"stats.disk_io.read_bytes\"},\"schema\":\"metric\",\"type\":\"max\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.disk_io.read_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.disk_io.read_bytes\"},\"type\":\"value\"}]},\"title\":\"Max Instance Disk I/O Bytes Written\",\"type\":\"histogram\"}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "bb2f9f80-5acf-11e7-b04c-fb55ed28b6e9",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "Wzc1LDFd",
       "attributes": {
         "title": "Min Instance Disk I/O Bytes Written",
-        "visState": "{\"title\":\"Min Instance Disk I/O Bytes Written\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk_io.write_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk_io.write_bytes\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_bytes\",\"customLabel\":\"\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance Disk I/O Bytes Written\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.disk_io.write_bytes\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.disk_io.write_bytes\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.disk_io.write_bytes\",\"customLabel\":\"\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "4c5541d0-5ad1-11e7-a812-bffabc6a4541",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "Wzc2LDFd",
       "attributes": {
         "title": "Min Instance Network I/O Bytes Sent",
-        "visState": "{\"title\":\"Min Instance Network I/O Bytes Sent\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.net_io.bytes_sent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.net_io.bytes_sent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_sent\",\"customLabel\":\"\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance Network I/O Bytes Sent\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.net_io.bytes_sent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.net_io.bytes_sent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_sent\",\"customLabel\":\"\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "611e9b70-5ad1-11e7-a812-bffabc6a4541",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "Wzc3LDFd",
       "attributes": {
         "title": "Mean Instance Network I/O Bytes Sent",
-        "visState": "{\"title\":\"Mean Instance Network I/O Bytes Sent\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.net_io.bytes_sent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.net_io.bytes_sent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_sent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance Network I/O Bytes Sent\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.net_io.bytes_sent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.net_io.bytes_sent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_sent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "6c86ae80-5ad1-11e7-a812-bffabc6a4541",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "Wzc4LDFd",
       "attributes": {
         "title": "Max Instance Network I/O Bytes Sent",
-        "visState": "{\"title\":\"Max Instance Network I/O Bytes Sent\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.net_io.bytes_sent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.net_io.bytes_sent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_sent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance Network I/O Bytes Sent\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.net_io.bytes_sent\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.net_io.bytes_sent\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_sent\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "8582b550-5ad1-11e7-a812-bffabc6a4541",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "Wzc5LDFd",
       "attributes": {
         "title": "Min Instance Network I/O Bytes Received",
-        "visState": "{\"title\":\"Min Instance Network I/O Bytes Received\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.net_io.bytes_recv\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.net_io.bytes_recv\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_recv\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Min Instance Network I/O Bytes Received\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Min stats.net_io.bytes_recv\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Min stats.net_io.bytes_recv\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"min\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_recv\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "923e9890-5ad1-11e7-a812-bffabc6a4541",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzgwLDFd",
       "attributes": {
         "title": "Mean Instance Network I/O Bytes Received",
-        "visState": "{\"title\":\"Mean Instance Network I/O Bytes Received\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.net_io.bytes_recv\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.net_io.bytes_recv\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_recv\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Mean Instance Network I/O Bytes Received\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Average stats.net_io.bytes_recv\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Average stats.net_io.bytes_recv\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_recv\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "a1611b90-5ad1-11e7-a812-bffabc6a4541",
       "type": "visualization",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzgxLDFd",
       "attributes": {
         "title": "Max Instance Network I/O Bytes Received",
-        "visState": "{\"title\":\"Max Instance Network I/O Bytes Received\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.net_io.bytes_recv\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.net_io.bytes_recv\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_recv\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
+        "visState": "{\"title\":\"Max Instance Network I/O Bytes Received\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"@timestamp per hour\"},\"type\":\"category\"}],\"defaultYExtents\":false,\"drawLinesBetweenPoints\":true,\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"interpolate\":\"linear\",\"legendPosition\":\"top\",\"radiusRatio\":9,\"scale\":\"linear\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Max stats.net_io.bytes_recv\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"setYExtents\":false,\"showCircles\":true,\"times\":[],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"setYExtents\":false,\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Max stats.net_io.bytes_recv\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"stats.net_io.bytes_recv\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}",
         "uiStateJSON": "{}",
         "description": "",
-        "savedSearchId": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
         "version": 1,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": "{\"filter\":[]}"
+        },
+        "savedSearchRefName": "search_0"
+      },
+      "references": [
+        {
+          "type": "search",
+          "name": "search_0",
+          "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a"
         }
+      ],
+      "migrationVersion": {
+        "visualization": "7.10.0"
       }
     },
     {
       "id": "9ef431b0-5aba-11e7-a451-0fe7e85b0f7a",
       "type": "search",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T01:25:14.663Z",
+      "version": "WzgyLDFd",
       "attributes": {
         "title": "instance_stats",
         "description": "",
@@ -660,44 +1373,44 @@
           "_source"
         ],
         "sort": [
-          "@timestamp",
-          "desc"
+          [
+            "@timestamp",
+            "desc"
+          ]
         ],
         "version": 1,
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"index\": \"75800890-8b5b-11e8-9fd0-236fca1cd40c\",\n  \"highlightAll\": true,\n  \"version\": true,\n  \"query\": {\n    \"query\": {\n      \"query_string\": {\n        \"query\": \"type.keyword:instance_stats\",\n        \"analyze_wildcard\": true\n      }\n    },\n    \"language\": \"lucene\"\n  },\n  \"filter\": []\n}"
+          "searchSourceJSON": "{\"highlightAll\":true,\"version\":true,\"query\":{\"query\":{\"query_string\":{\"query\":\"type.keyword:instance_stats\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
         }
+      },
+      "references": [
+        {
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern",
+          "id": "75800890-8b5b-11e8-9fd0-236fca1cd40c"
+        }
+      ],
+      "migrationVersion": {
+        "search": "7.9.3"
       }
     },
     {
       "id": "75800890-8b5b-11e8-9fd0-236fca1cd40c",
       "type": "index-pattern",
-      "updated_at": "2019-12-03T17:00:58.125Z",
-      "version": 22,
+      "namespaces": [
+        "default"
+      ],
+      "updated_at": "2023-03-23T22:29:19.615Z",
+      "version": "WzI0NTMsMV0=",
       "attributes": {
         "title": "logstash-*",
         "timeFieldName": "@timestamp",
-        "fields": "[{\"name\":\"@timestamp\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"@version\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_score\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_source\",\"type\":\"_source\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"geoip.ip\",\"type\":\"ip\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"geoip.latitude\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"geoip.location\",\"type\":\"geo_point\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"geoip.longitude\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.container_image_name\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.container_image_name.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.container_image_url\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.container_image_url.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.delivery_info.exchange\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.delivery_info.exchange.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.delivery_info.priority\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.delivery_info.redelivered\",\"type\":\"boolean\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.delivery_info.routing_key\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.delivery_info.routing_key.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.cmd_duration\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.cmd_end\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.cmd_start\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.context_file\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.context_file.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.datasets_cfg_file\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.datasets_cfg_file.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.dedup\",\"type\":\"boolean\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.duration\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.execute_node\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.execute_node.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.architecture\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.architecture.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.domain\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.domain.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ec2_instance_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ec2_instance_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ec2_instance_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ec2_instance_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ec2_placement_availability_zone\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ec2_placement_availability_zone.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.fqdn\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.fqdn.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.hardwaremodel\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.hardwaremodel.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.hostname\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.hostname.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.hysds_execute_node\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.hysds_execute_node.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.hysds_public_ip\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.hysds_public_ip.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ipaddress\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ipaddress.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.ipaddress_eth0\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.ipaddress_eth0.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.is_virtual\",\"type\":\"boolean\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.memoryfree\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.memoryfree.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.memorysize\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.memorysize.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.operatingsystem\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.operatingsystem.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.operatingsystemrelease\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.operatingsystemrelease.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.osfamily\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.osfamily.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.physicalprocessorcount\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.processorcount\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.swapfree\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.swapfree.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.swapsize\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.swapsize.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.uptime\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.uptime.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.facts.virtual\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.facts.virtual.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_dir\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_dir.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_payload.job_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_payload.job_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_payload.payload_task_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_payload.payload_task_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_queue\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_queue.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.job_url\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.job_url.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.duration\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.path\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.inputs_localized.path.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.time_end\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.time_start\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.transfer_rate\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.inputs_localized.url\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.inputs_localized.url.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.job_dir_size\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.availability_time\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.processing_latency\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.processing_start_time\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.product_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.product_provenance.product_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.product_provenance.total_latency\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.browse_urls\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.browse_urls.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.dataset\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.dataset.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.dataset_level\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.dataset_level.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.dataset_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.dataset_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.disk_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.duration\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.index.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.ipath\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.ipath.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.path\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.path.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.system_version\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.system_version.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.time_end\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.time_start\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.transfer_rate\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.products_staged.urls\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.products_staged.urls.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.major\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.op\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.op.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.value\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.major\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.op\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.op.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.value\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.percpu_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_kernelmode\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_usermode\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.hugetlb_stats.1GB.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.hugetlb_stats.2MB.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.cache\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_tcp_usage.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_tcp_usage.limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_usage.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_usage.limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.active_anon\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.active_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.cache\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.hierarchical_memory_limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.hierarchical_memsw_limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.inactive_anon\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.inactive_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.mapped_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgfault\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgmajfault\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgpgin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgpgout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.rss\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.rss_huge\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.swap\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_active_anon\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_active_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_cache\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_inactive_anon\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_inactive_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_mapped_file\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgfault\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgmajfault\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgpgin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgpgout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_rss\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_rss_huge\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_swap\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_unevictable\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.unevictable\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.max_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.failcnt\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.usage\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.cgroups.pids_stats.current\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.sys_cpu_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.user_cpu_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.metrics.usage_stats.wall_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.payload_hash\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.payload_hash.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.pid\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.public_ip\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.public_ip.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.soft_time_limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.status\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.stderr\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.stderr.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.stdout\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.job_info.stdout.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.time_end\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.time_limit\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.time_queued\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.job_info.time_start\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.name\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.name.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.priority\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.tag\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.tag.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job.task_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job.task_id.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"job_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"job_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.cpu\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.device\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.all.device.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.fs_opts\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.all.fs_opts.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.fs_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.all.fs_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.mount_point\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.all.mount_point.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.all.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.device\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.data.device.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.fs_opts\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.data.fs_opts.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.fs_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.data.fs_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.mount_point\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.data.mount_point.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.data.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.device\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.root.device.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.fs_opts\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.root.fs_opts.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.fs_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.root.fs_type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.mount_point\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.disk.root.mount_point.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk.root.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.busy_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.read_bytes\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.read_count\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.read_merged_count\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.read_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.write_bytes\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.write_count\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.write_merged_count\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.disk_io.write_time\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.host\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"stats.host.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.host_up\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.active\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.available\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.buffers\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.cached\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.inactive\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.shared\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.slab\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.memory.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.bytes_recv\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.bytes_sent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.dropin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.dropout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.errin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.errout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.packets_recv\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.net_io.packets_sent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.per_cpu\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.free\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.percent\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.sin\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.sout\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.total\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"stats.swap.used\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"type.keyword\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"input_localized\",\"type\":\"number\",\"count\":0,\"scripted\":true,\"script\":\"if (doc['job.job_info.metrics.inputs_localized.disk_usage'].value > 0) { return 1; } return 0;\",\"lang\":\"painless\",\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"product_staged\",\"type\":\"number\",\"count\":0,\"scripted\":true,\"script\":\"if (doc['job.job_info.metrics.products_staged.disk_usage'].value > 0) { return 1; } return 0;\",\"lang\":\"painless\",\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false}]",
-        "fieldFormatMap": "{\"job.job_info.metrics.inputs_localized.disk_usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.products_staged.disk_usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.job_dir_size\":{\"id\":\"bytes\"},\"job.job_info.cmd_duration\":{\"id\":\"duration\",\"params\":{\"outputFormat\":\"asSeconds\"}},\"job.job_info.duration\":{\"id\":\"duration\",\"params\":{\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.inputs_localized.duration\":{\"id\":\"duration\",\"params\":{\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.products_staged.duration\":{\"id\":\"duration\",\"params\":{\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.wall_time\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.user_cpu_time\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.sys_cpu_time\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.percpu_usage\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_kernelmode\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_usermode\":{\"id\":\"duration\",\"params\":{\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.cache\":{\"id\":\"bytes\"},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.max_usage\":{\"id\":\"bytes\"},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.usage\":{\"id\":\"bytes\"}}"
-      }
-    },
-    {
-      "id": "5e0abbd0-5abd-11e7-a451-0fe7e85b0f7a",
-      "type": "dashboard",
-      "updated_at": "2019-12-03T12:44:56.527Z",
-      "version": 1,
-      "attributes": {
-        "title": "Worker Metrics",
-        "hits": 0,
-        "description": "",
-        "panelsJSON": "[{\"col\":1,\"id\":\"9da63870-5abb-11e7-a451-0fe7e85b0f7a\",\"panelIndex\":1,\"row\":1,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"eab7a740-5abe-11e7-a451-0fe7e85b0f7a\",\"panelIndex\":2,\"row\":4,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"f8a84480-5abf-11e7-a451-0fe7e85b0f7a\",\"panelIndex\":3,\"row\":7,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"51b18aa0-5ac0-11e7-a451-0fe7e85b0f7a\",\"panelIndex\":4,\"row\":7,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"61d1f5a0-5ac0-11e7-a451-0fe7e85b0f7a\",\"panelIndex\":5,\"row\":7,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"74dc9d60-5ac2-11e7-a8a3-37f88d4052ad\",\"panelIndex\":6,\"row\":10,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"8a967180-5ac2-11e7-a8a3-37f88d4052ad\",\"panelIndex\":7,\"row\":10,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"9503d0e0-5ac2-11e7-a8a3-37f88d4052ad\",\"panelIndex\":8,\"row\":10,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"fd9d7700-5ac2-11e7-a8a3-37f88d4052ad\",\"panelIndex\":9,\"row\":13,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"0eceb5c0-5ac3-11e7-a8a3-37f88d4052ad\",\"panelIndex\":10,\"row\":13,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"199fb8f0-5ac3-11e7-a8a3-37f88d4052ad\",\"panelIndex\":11,\"row\":13,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"1de2ab10-5ac9-11e7-a8a3-37f88d4052ad\",\"panelIndex\":12,\"row\":16,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"2bc24dd0-5ac9-11e7-a8a3-37f88d4052ad\",\"panelIndex\":13,\"row\":16,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"3ae9d9e0-5ac9-11e7-a8a3-37f88d4052ad\",\"panelIndex\":14,\"row\":16,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"1e200cc0-5aca-11e7-a8a3-37f88d4052ad\",\"panelIndex\":15,\"row\":19,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"2a828560-5aca-11e7-a8a3-37f88d4052ad\",\"panelIndex\":16,\"row\":19,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"358546f0-5aca-11e7-a8a3-37f88d4052ad\",\"panelIndex\":17,\"row\":19,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"812f8c00-5aca-11e7-a8a3-37f88d4052ad\",\"panelIndex\":18,\"row\":22,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"8c65b9a0-5aca-11e7-a8a3-37f88d4052ad\",\"panelIndex\":19,\"row\":22,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"9a533f10-5aca-11e7-a8a3-37f88d4052ad\",\"panelIndex\":20,\"row\":22,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"ecd575d0-5acc-11e7-a8a3-37f88d4052ad\",\"panelIndex\":21,\"row\":28,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"d3163420-5ace-11e7-b04c-fb55ed28b6e9\",\"panelIndex\":23,\"row\":28,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"c4d314a0-5ace-11e7-b04c-fb55ed28b6e9\",\"panelIndex\":24,\"row\":28,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"0a2aaf80-5acb-11e7-a8a3-37f88d4052ad\",\"panelIndex\":25,\"row\":25,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"20dd89a0-5acb-11e7-a8a3-37f88d4052ad\",\"panelIndex\":26,\"row\":25,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"35bd5170-5acb-11e7-a8a3-37f88d4052ad\",\"panelIndex\":27,\"row\":25,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"7d936030-5acf-11e7-b04c-fb55ed28b6e9\",\"panelIndex\":28,\"row\":31,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"9724c930-5acf-11e7-b04c-fb55ed28b6e9\",\"panelIndex\":29,\"row\":31,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"a55f8440-5acf-11e7-b04c-fb55ed28b6e9\",\"panelIndex\":30,\"row\":31,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"cb080500-5acf-11e7-b04c-fb55ed28b6e9\",\"panelIndex\":31,\"row\":34,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":9,\"id\":\"daba9300-5acf-11e7-b04c-fb55ed28b6e9\",\"panelIndex\":32,\"row\":34,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"bb2f9f80-5acf-11e7-b04c-fb55ed28b6e9\",\"panelIndex\":33,\"row\":34,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"size_x\":4,\"size_y\":3,\"panelIndex\":34,\"type\":\"visualization\",\"id\":\"4c5541d0-5ad1-11e7-a812-bffabc6a4541\",\"col\":1,\"row\":37},{\"size_x\":4,\"size_y\":3,\"panelIndex\":35,\"type\":\"visualization\",\"id\":\"611e9b70-5ad1-11e7-a812-bffabc6a4541\",\"col\":5,\"row\":37},{\"size_x\":4,\"size_y\":3,\"panelIndex\":36,\"type\":\"visualization\",\"id\":\"6c86ae80-5ad1-11e7-a812-bffabc6a4541\",\"col\":9,\"row\":37},{\"size_x\":4,\"size_y\":3,\"panelIndex\":37,\"type\":\"visualization\",\"id\":\"8582b550-5ad1-11e7-a812-bffabc6a4541\",\"col\":1,\"row\":40},{\"size_x\":4,\"size_y\":3,\"panelIndex\":38,\"type\":\"visualization\",\"id\":\"923e9890-5ad1-11e7-a812-bffabc6a4541\",\"col\":5,\"row\":40},{\"size_x\":4,\"size_y\":3,\"panelIndex\":39,\"type\":\"visualization\",\"id\":\"a1611b90-5ad1-11e7-a812-bffabc6a4541\",\"col\":9,\"row\":40}]",
-        "optionsJSON": "{\"darkTheme\":true}",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "timeRestore": false,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}],\"highlightAll\":true,\"version\":true}"
-        }
+        "fields": "[{\"count\":0,\"name\":\"@timestamp\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"@version\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_index\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_score\",\"type\":\"number\",\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_source\",\"type\":\"_source\",\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"geoip.ip\",\"type\":\"ip\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"geoip.latitude\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"geoip.location\",\"type\":\"geo_point\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"geoip.longitude\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.container_image_name\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.container_image_name.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.container_image_url\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.container_image_url.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.delivery_info.exchange\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.delivery_info.exchange.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.delivery_info.priority\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.delivery_info.redelivered\",\"type\":\"boolean\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.delivery_info.routing_key\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.delivery_info.routing_key.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.cmd_duration\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.cmd_end\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.cmd_start\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.context_file\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.context_file.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.datasets_cfg_file\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.datasets_cfg_file.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.dedup\",\"type\":\"boolean\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.duration\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.execute_node\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.execute_node.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.architecture\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.architecture.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.domain\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.domain.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ec2_instance_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ec2_instance_id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ec2_instance_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ec2_instance_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ec2_placement_availability_zone\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ec2_placement_availability_zone.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.fqdn\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.fqdn.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.hardwaremodel\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.hardwaremodel.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.hostname\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.hostname.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.hysds_execute_node\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.hysds_execute_node.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.hysds_public_ip\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.hysds_public_ip.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ipaddress\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ipaddress.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.ipaddress_eth0\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.ipaddress_eth0.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.is_virtual\",\"type\":\"boolean\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.memoryfree\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.memoryfree.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.memorysize\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.memorysize.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.operatingsystem\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.operatingsystem.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.operatingsystemrelease\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.operatingsystemrelease.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.osfamily\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.osfamily.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.physicalprocessorcount\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.processorcount\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.swapfree\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.swapfree.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.swapsize\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.swapsize.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.uptime\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.uptime.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.facts.virtual\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.facts.virtual.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_dir\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_dir.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_payload.job_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_payload.job_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_payload.payload_task_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_payload.payload_task_id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_queue\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_queue.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.job_url\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.job_url.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.disk_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.duration\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.path\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.path.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.time_end\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.time_start\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.transfer_rate\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.url\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.inputs_localized.url.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.job_dir_size\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.availability_time\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.processing_latency\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.processing_start_time\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.product_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.product_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.product_provenance.total_latency\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.browse_urls\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.browse_urls.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset_level\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset_level.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.dataset_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.disk_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.duration\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.index\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.index.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.ipath\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.ipath.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.path\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.path.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.system_version\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.system_version.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.time_end\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.time_start\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.transfer_rate\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.urls\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.products_staged.urls.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.major\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.op\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.op.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_service_bytes_recursive.value\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.major\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.op\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.op.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.blkio_stats.io_serviced_recursive.value\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.percpu_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_kernelmode\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_usermode\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.hugetlb_stats.1GB.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.hugetlb_stats.2MB.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.cache\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_tcp_usage.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_tcp_usage.limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_usage.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.kernel_usage.limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.active_anon\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.active_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.cache\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.hierarchical_memory_limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.hierarchical_memsw_limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.inactive_anon\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.inactive_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.mapped_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgfault\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgmajfault\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgpgin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.pgpgout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.rss\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.rss_huge\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.swap\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_active_anon\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_active_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_cache\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_inactive_anon\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_inactive_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_mapped_file\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgfault\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgmajfault\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgpgin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_pgpgout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_rss\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_rss_huge\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_swap\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.total_unevictable\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.stats.unevictable\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.max_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.failcnt\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.usage\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.cgroups.pids_stats.current\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.sys_cpu_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.user_cpu_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.metrics.usage_stats.wall_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.payload_hash\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.payload_hash.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.pid\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.public_ip\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.public_ip.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.soft_time_limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.status\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.stderr\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.stderr.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.stdout\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.job_info.stdout.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.time_end\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.time_limit\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.time_queued\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.job_info.time_start\",\"type\":\"date\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.name\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.name.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.priority\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.tag\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.tag.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job.task_id\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job.task_id.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"job_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"job_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.cpu\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.device\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.all.device.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.fs_opts\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.all.fs_opts.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.fs_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.all.fs_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.mount_point\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.all.mount_point.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.all.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.device\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.data.device.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.fs_opts\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.data.fs_opts.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.fs_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.data.fs_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.mount_point\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.data.mount_point.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.data.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.device\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.root.device.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.fs_opts\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.root.fs_opts.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.fs_type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.root.fs_type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.mount_point\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.disk.root.mount_point.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk.root.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.busy_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.read_bytes\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.read_count\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.read_merged_count\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.read_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.write_bytes\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.write_count\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.write_merged_count\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.disk_io.write_time\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.host\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"stats.host.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.host_up\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.active\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.available\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.buffers\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.cached\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.inactive\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.shared\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.slab\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.memory.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.bytes_recv\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.bytes_sent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.dropin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.dropout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.errin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.errout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.packets_recv\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.net_io.packets_sent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.per_cpu\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.free\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.percent\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.sin\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.sout\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.total\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"stats.swap.used\",\"type\":\"number\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"type\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"type.keyword\",\"type\":\"string\",\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]",
+        "fieldFormatMap": "{\"job.job_info.cmd_duration\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"outputFormat\":\"asSeconds\"}},\"job.job_info.duration\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.inputs_localized.disk_usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.inputs_localized.duration\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.job_dir_size\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.products_staged.disk_usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.products_staged.duration\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.percpu_usage\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.total_usage\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_kernelmode\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.cpu_stats.cpu_usage.usage_in_usermode\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.cache\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.max_usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_usage.usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.max_usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.cgroups.memory_stats.usage.usage\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.usage_stats.sys_cpu_time\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.user_cpu_time\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.usage_stats.wall_time\":{\"id\":\"duration\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"},\"inputFormat\":\"nanoseconds\",\"outputFormat\":\"asSeconds\"}},\"job.job_info.metrics.inputs_localized.transfer_rate\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}},\"job.job_info.metrics.products_staged.transfer_rate\":{\"id\":\"bytes\",\"params\":{\"parsedUrl\":{\"origin\":\"https://100.104.10.138\",\"pathname\":\"/metrics/app/management/kibana/indexPatterns/patterns/logstash-*/field/job.job_info.metrics.inputs_localized.transfer_rate\",\"basePath\":\"/metrics\"}}}}"
+      },
+      "references": [],
+      "migrationVersion": {
+        "index-pattern": "7.6.0"
       }
     }
   ]


### PR DESCRIPTION
This PR fixes an issue in the job metrics dashboard for the counts of generated products and inputs localized by jobs. It originally used a painless script to generate custom metrics for these but has been simplified to count up the job's `job.job_info.metrics.products_staged.id.keyword` and `job.job_info.metrics.inputs_localized.url.keyword`, respectively. 

Additionally, this PR updates the Kibana export JSON files for the dashboards (Job Metrics, Worker Metrics, Minimal OPS UI) for ELK 7.10.2. 