### PR TITLE
HC-469: Cannot properly update GRQ when cluster is configured with AWS OpenSearch Service

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -476,7 +476,8 @@ def install_base_es_template():
         "es_template-base.json",
         "/tmp/es_template-base.json"
     )
-    run("curl -XPUT 'localhost:9200/_template/index_defaults?pretty' -H 'Content-Type: application/json' -d@/tmp/es_template-base.json")
+    with prefix('source %s/bin/activate' % hysds_dir):
+        run(f'{hysds_dir}/ops/{role}/scripts/install_es_template.sh /tmp/es_template-base.json')
 
 
 def install_es_policy():

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -477,7 +477,7 @@ def install_base_es_template():
         "/tmp/es_template-base.json"
     )
     with prefix('source %s/bin/activate' % hysds_dir):
-        run(f'{hysds_dir}/ops/{role}/scripts/install_es_template.sh /tmp/es_template-base.json')
+        run(f'{hysds_dir}/ops/{role}/scripts/install_base_es_template.sh /tmp/es_template-base.json')
 
 
 def install_es_policy():

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -476,8 +476,11 @@ def install_base_es_template():
         "es_template-base.json",
         "/tmp/es_template-base.json"
     )
+    dir = role
+    if role == "grq":
+        dir = "grq2"
     with prefix('source %s/bin/activate' % hysds_dir):
-        run(f'{hysds_dir}/ops/{role}/scripts/install_base_es_template.sh /tmp/es_template-base.json')
+        run(f'{hysds_dir}/ops/{dir}/scripts/install_base_es_template.sh /tmp/es_template-base.json')
 
 
 def install_es_policy():

--- a/sdscli/adapters/hysds/update.py
+++ b/sdscli/adapters/hysds/update.py
@@ -450,11 +450,6 @@ def update_grq(conf, ndeps=False, config_only=False, comp='grq'):
                     '~/sciflo/ops/pele', ndeps, roles=[comp])
             bar.update()
 
-        # set default ES shard number
-        set_bar_desc(bar, 'Setting default ES shard number')
-        execute(fab.install_base_es_template, roles=[comp])
-        bar.update()
-
         # update celery config
         set_bar_desc(bar, 'Updating celery config')
         execute(fab.rm_rf, '~/sciflo/ops/hysds/celeryconfig.py', roles=[comp])
@@ -466,6 +461,11 @@ def update_grq(conf, ndeps=False, config_only=False, comp='grq'):
         set_bar_desc(bar, 'Updating grq2 config')
         execute(fab.rm_rf, '~/sciflo/ops/grq2/settings.cfg', roles=[comp])
         execute(fab.send_grq2conf, roles=[comp])
+        bar.update()
+
+        # set default ES shard number
+        set_bar_desc(bar, 'Setting default ES shard number')
+        execute(fab.install_base_es_template, roles=[comp])
         bar.update()
 
         # update pele config

--- a/sdscli/adapters/hysds/update.py
+++ b/sdscli/adapters/hysds/update.py
@@ -66,6 +66,13 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
             execute(fab.npm_install_package_json, '~/mozart/ops/hysds_ui', roles=[comp])
             bar.update()
 
+        # update celery config
+        set_bar_desc(bar, 'Updating celery config')
+        execute(fab.rm_rf, '~/mozart/ops/hysds/celeryconfig.py', roles=[comp])
+        execute(fab.rm_rf, '~/mozart/ops/hysds/celeryconfig.pyc', roles=[comp])
+        execute(fab.send_celeryconf, 'mozart', roles=[comp])
+        bar.update()
+
         # set default ES shard number
         set_bar_desc(bar, 'Setting default ES shard number')
         execute(fab.install_base_es_template, roles=[comp])
@@ -84,13 +91,6 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
         # update logstash jvm.options to increase heap size
         set_bar_desc(bar, 'Updating logstash jvm.options')
         execute(fab.send_logstash_jvm_options, 'mozart', roles=[comp])
-        bar.update()
-
-        # update celery config
-        set_bar_desc(bar, 'Updating celery config')
-        execute(fab.rm_rf, '~/mozart/ops/hysds/celeryconfig.py', roles=[comp])
-        execute(fab.rm_rf, '~/mozart/ops/hysds/celeryconfig.pyc', roles=[comp])
-        execute(fab.send_celeryconf, 'mozart', roles=[comp])
         bar.update()
 
         # update supervisor config


### PR DESCRIPTION
This PR resolves the issue where updating GRQ would break when a cluster is configured with AWS OpenSearch Service. This PR involved the following changes:

- Installing the base ES template using a python tool created in the following PRs:
    - https://github.com/hysds/mozart/pull/49
    - https://github.com/hysds/grq2/pull/59
- This python tool allows us to properly install the base templates whether the cluster is configured with local GRQ or AWS OpenSearch.

- Made the following updates to the mozart update function:
  - Make sure to push the celery config out first before calling the install base ES template tool as that tool relies on the existence of the celeryconfig.py in order for that tool to run properly.

- Made the following updates to the grq update function:
  -   Make sure to push out the settings.cfg first before calling the install base ES template tool as that tool relies on this config file existing on GRQ in order for the tool to run properly.


Force branch is running on the SWOT side to test these PR updates: https://swot-pcm-ci.jpl.nasa.gov/job/force-branches/job/ci-E2E_NIGHTLY-swot-pcm_develop-force-branch/881/

Also, as part of my test, I created some procedures on how to configure the cluster to go from local GRQ to AWS ES post deployment: https://wiki.jpl.nasa.gov/display/swotsds/Configure+Cluster+to+use+AWS+OpenSearch+Service+Post+Deployment

This involved running the `sds update` commands, which I verified with these updates that they worked as intended.