### PR TITLE
HC-496: Updates to optionally support a separate Mozart ES cluster deployment

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -466,7 +466,7 @@ def install_pkg_es_templates():
     if role not in ('grq', 'mozart'):
         raise RuntimeError("Invalid fabric function for %s." % role)
     with prefix('source %s/bin/activate' % hysds_dir):
-        run('%s/ops/mozart/scripts/install_es_template.sh %s' % (hysds_dir, role))
+        run('%s/ops/mozart/scripts/install_es_template.sh' % (hysds_dir))
 
 
 def install_base_es_template():

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -519,7 +519,7 @@ def install_mozart_es_templates():
             target_path
         )
     with prefix('source %s/bin/activate' % hysds_dir):
-        run(f"{ops_dir}/mozart/scripts/install_es_template.sh --install_job_templates --template_dir {target_dir}")
+        run(f"{hysds_dir}/ops/mozart/scripts/install_es_template.sh --install_job_templates --template_dir {target_dir}")
 
 
 ##########################

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -494,7 +494,7 @@ def install_es_policy():
     )
 
     with prefix('source %s/bin/activate' % hysds_dir):
-        run(f'{hysds_dir}/ops/{role}/scripts/install_ilm_policy.sh --policy_file ${target_file}')
+        run(f'{hysds_dir}/ops/{role}/scripts/install_ilm_policy.sh --policy_file {target_file}')
 
 
 def install_mozart_es_templates():

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -484,16 +484,17 @@ def install_base_es_template():
 
 
 def install_es_policy():
+    role, hysds_dir, hostname = resolve_role()
+
     policy_file_name = "es_ilm_policy_mozart.json"
     target_file = f"{ops_dir}/mozart/etc/{policy_file_name}"
     send_template(
         policy_file_name,
         target_file
     )
-    role, hysds_dir, hostname = resolve_role()
 
     with prefix('source %s/bin/activate' % hysds_dir):
-        run(f'{hysds_dir}/ops/{dir}/scripts/install_ilm_policy.sh --policy_file ${target_file}')
+        run(f'{hysds_dir}/ops/{role}/scripts/install_ilm_policy.sh --policy_file ${target_file}')
 
 
 def install_mozart_es_templates():

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -501,6 +501,7 @@ def install_mozart_es_templates():
     # install index templates
     # Only job_status.template has ILM policy attached
     # HC-451 will focus on adding ILM to worker, task, and event status indices
+    role, hysds_dir, hostname = resolve_role()
 
     # template files located in ~/.sds/files
     templates = [
@@ -517,7 +518,7 @@ def install_mozart_es_templates():
             template,
             target_path
         )
-    with prefix('source %s/bin/activate' % ops_dir):
+    with prefix('source %s/bin/activate' % hysds_dir):
         run(f"{ops_dir}/mozart/scripts/install_es_template.sh --install_job_templates --template_dir {target_dir}")
 
 

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -490,7 +490,10 @@ def install_es_policy():
         policy_file_name,
         target_file
     )
-    run(f"curl -XPUT 'localhost:9200/_ilm/policy/ilm_policy_mozart?pretty' -H 'Content-Type: application/json' -d@{target_file}")
+    role, hysds_dir, hostname = resolve_role()
+
+    with prefix('source %s/bin/activate' % hysds_dir):
+        run(f'{hysds_dir}/ops/{dir}/scripts/install_ilm_policy.sh --policy_file ${target_file}')
 
 
 def install_mozart_es_templates():
@@ -505,18 +508,16 @@ def install_mozart_es_templates():
         "task_status.template",
         "event_status.template"
     ]
-
+    target_dir = f"{ops_dir}/mozart/etc"
     for template in templates:
         # Copy templates to etc/ directory
-        target_path = f"{ops_dir}/mozart/etc/{template}"
+        target_path = f"{target_dir}/{template}"
         send_template(
             template,
             target_path
         )
-        template_doc_name = template.split(".template")[0]
-        print(f"Creating ES index template for {template}")
-        run(f"curl -XPUT 'localhost:9200/_index_template/{template_doc_name}?pretty' "
-            f"-H 'Content-Type: application/json' -d@{target_path}")
+    with prefix('source %s/bin/activate' % ops_dir):
+        run(f"{ops_dir}/mozart/scripts/install_es_template.sh --install_job_templates --template_dir {target_dir}")
 
 
 ##########################

--- a/sdscli/adapters/hysds/status.py
+++ b/sdscli/adapters/hysds/status.py
@@ -137,9 +137,9 @@ def print_tps_status(conf, comp, debug=False):
         #                   conf.get('MOZART_REDIS_PVT_IP'))
         ret = execute(fab.systemctl, 'status', 'redis', roles=[comp])
         print_service_status('redis', ret, debug)
-        # print_es_status(conf.get('MOZART_ES_PVT_IP'))
-        ret = execute(fab.systemctl, 'status', 'elasticsearch', roles=[comp])
-        print_service_status('elasticsearch', ret, debug)
+        print_es_status(conf.get('MOZART_ES_PVT_IP'))
+        #ret = execute(fab.systemctl, 'status', 'elasticsearch', roles=[comp])
+        #print_service_status('elasticsearch', ret, debug)
     elif comp == 'metrics':
         print_tps_header(comp)
         # print_redis_status(conf.get('METRICS_REDIS_PASSWORD'),

--- a/sdscli/adapters/hysds/status.py
+++ b/sdscli/adapters/hysds/status.py
@@ -75,7 +75,7 @@ def print_redis_status(password, host):
 
 def print_es_status(host):
     """Print status of ES server."""
-
+    print(f"[{host}] Pinging ElasticSearch")
     service = "elasticsearch"
     status = "inactive"
     try:

--- a/sdscli/adapters/hysds/status.py
+++ b/sdscli/adapters/hysds/status.py
@@ -76,13 +76,22 @@ def print_redis_status(password, host):
 def print_es_status(host):
     """Print status of ES server."""
 
+    service = "elasticsearch"
+    status = "inactive"
     try:
         es = elasticsearch.Elasticsearch([host], verify_certs=False)
-        es.ping()
-        print(("ES: ", highlight("RUNNING")))
+        result = es.ping()
+        if result is True:
+            status = "active"
     except Exception as e:
-        print(("ES: ", blink(highlight("NOT RUNNING", 'red', True))))
-        print(e)
+        # Should we print the exception here?
+        print(f"Error while getting ElasticSearch status:\n{str(e)}")
+        pass
+
+    if status == 'active':
+        print(("{}: {}".format(service, highlight(status.upper()))))
+    else:
+        print(("{}: {}".format(service, blink(highlight(status.upper(), 'red')))))
 
 
 def print_http_status(server, url):
@@ -137,14 +146,14 @@ def print_tps_status(conf, comp, debug=False):
         #                   conf.get('METRICS_REDIS_PVT_IP'))
         ret = execute(fab.systemctl, 'status', 'redis', roles=[comp])
         print_service_status('redis', ret, debug)
-        # print_es_status(conf.get('METRICS_ES_PVT_IP')) # ES accessible only from localhost
-        ret = execute(fab.systemctl, 'status', 'elasticsearch', roles=[comp])
-        print_service_status('elasticsearch', ret, debug)
+        print_es_status(conf.get('METRICS_ES_PVT_IP')) # ES accessible only from localhost
+        #ret = execute(fab.systemctl, 'status', 'elasticsearch', roles=[comp])
+        #print_service_status('elasticsearch', ret, debug)
     elif comp == 'grq':
         print_tps_header(comp)
-        # print_es_status(conf.get('GRQ_ES_PVT_IP'))
-        ret = execute(fab.systemctl, 'status', 'elasticsearch', roles=[comp])
-        print_service_status('elasticsearch', ret, debug)
+        print_es_status(conf.get('GRQ_ES_PVT_IP'))
+        #ret = execute(fab.systemctl, 'status', 'elasticsearch', roles=[comp])
+        #print_service_status('elasticsearch', ret, debug)
     elif comp == 'ci':
         print_tps_header(comp)
         #print_http_status("Jenkins", "http://{}:8080".format(conf.get('CI_PVT_IP')))


### PR DESCRIPTION
- Updated the installation of the Mozart ILM policy and templates such that they call a script now instead of the localhost:9200 endpoint.
- Regarding installation of the templates, updated the existing `install_es_template.sh` in order to do this. See mozart repo PR for more details: https://github.com/hysds/mozart/pull/53
- Also modified the `sds status` command such that when we display the ElasticSearch status, we ping the actual server by relying on the IP set in the sds config as opposed to simply relying on `systemctl status elasticsearch`, which always assumes that Elasticsearch is running on the host machine.

![image](https://github.com/sdskit/sdscli/assets/42812746/8091bca8-3138-4d23-93b0-e4dcbe359628)
