### PR TITLE
hot-fix: Fix the index pattern in the ISM Mozart policy

### DIFF
--- a/sdscli/adapters/hysds/files/opensearch_ism_policy_mozart.json
+++ b/sdscli/adapters/hysds/files/opensearch_ism_policy_mozart.json
@@ -37,7 +37,7 @@
       }
     ],
     "ism_template": {
-      "index_patterns": ["*-status.*"]
+      "index_patterns": ["*_status*"]
     }
   }
 }


### PR DESCRIPTION
This hot fix updates the ISM Mozart policy such that the index pattern is set correctly in order to attach the ISM Mozart policy to those job related status indices that get created daily:

- event_status*
- task_status*
- worker_status*
- job_status*