### PR TITLE
Enable importing of container name-only images and user-rules via sdscli

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"


### PR DESCRIPTION
Ticket: https://hysds-core.atlassian.net/browse/HC-517

Add support in sdscli for container specifications which do not specify a container_url and only specify a container_name. This behavior is already supported within hysds-core and only requires a tooling change to the sds pkg import command.

https://github.com/hysds/hysds/blob/944d3a89997b1aff416dc627b095a6b5e10b2242/hysds/containers/base.py#L279-L283 

Additionally, add support for importing user rules from a package if part of the package.