### PR TITLE
HC-522: Updates to support deployment of Verdi to run with Podman

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/files/install.sh
+++ b/sdscli/adapters/hysds/files/install.sh
@@ -30,9 +30,10 @@ fi
 # write supervisord from template
 IPADDRESS_ETH0=$(/usr/sbin/ifconfig $(/usr/sbin/route | awk '/default/{print $NF}') | grep 'inet ' | sed 's/addr://' | awk '{print $2}') 
 FQDN=$IPADDRESS_ETH0
+HOST_VERDI_HOME={{ HOST_VERDI_HOME or $HOME }}
 sed "s/__IPADDRESS_ETH0__/$IPADDRESS_ETH0/g" $HOME/verdi/etc/supervisord.conf.tmpl | \
   sed "s/__HYSDS_GPU_AVAILABLE__/$GPUS/g" | \
-  sed "s/__HOST_VERDI_HOME__/$HOME/g" | \
+  sed "s/__HOST_VERDI_HOME__/$HOST_VERDI_HOME/g" | \
   sed "s/__HOST_USER__/$USER/g" | \
   sed "s/__FQDN__/$FQDN/g" > $HOME/verdi/etc/supervisord.conf
 

--- a/sdscli/adapters/hysds/files/install.sh
+++ b/sdscli/adapters/hysds/files/install.sh
@@ -32,6 +32,8 @@ IPADDRESS_ETH0=$(/usr/sbin/ifconfig $(/usr/sbin/route | awk '/default/{print $NF
 FQDN=$IPADDRESS_ETH0
 sed "s/__IPADDRESS_ETH0__/$IPADDRESS_ETH0/g" $HOME/verdi/etc/supervisord.conf.tmpl | \
   sed "s/__HYSDS_GPU_AVAILABLE__/$GPUS/g" | \
+  sed "s/__HOST_VERDI_HOME__/$HOME/g" | \
+  sed "s/__HOST_USER__/$USER/g" | \
   sed "s/__FQDN__/$FQDN/g" > $HOME/verdi/etc/supervisord.conf
 
 # move creds

--- a/sdscli/adapters/hysds/files/install.sh
+++ b/sdscli/adapters/hysds/files/install.sh
@@ -30,7 +30,7 @@ fi
 # write supervisord from template
 IPADDRESS_ETH0=$(/usr/sbin/ifconfig $(/usr/sbin/route | awk '/default/{print $NF}') | grep 'inet ' | sed 's/addr://' | awk '{print $2}') 
 FQDN=$IPADDRESS_ETH0
-HOST_VERDI_HOME={{ HOST_VERDI_HOME or $HOME }}
+HOST_VERDI_HOME={{ HOST_VERDI_HOME or '$HOME' }}
 sed "s/__IPADDRESS_ETH0__/$IPADDRESS_ETH0/g" $HOME/verdi/etc/supervisord.conf.tmpl | \
   sed "s/__HYSDS_GPU_AVAILABLE__/$GPUS/g" | \
   sed "s/__HOST_VERDI_HOME__/$HOST_VERDI_HOME/g" | \

--- a/sdscli/adapters/hysds/files/install.sh
+++ b/sdscli/adapters/hysds/files/install.sh
@@ -31,9 +31,10 @@ fi
 IPADDRESS_ETH0=$(/usr/sbin/ifconfig $(/usr/sbin/route | awk '/default/{print $NF}') | grep 'inet ' | sed 's/addr://' | awk '{print $2}') 
 FQDN=$IPADDRESS_ETH0
 HOST_VERDI_HOME={{ HOST_VERDI_HOME or '$HOME' }}
+ESCAPED_HOST_VERDI_HOME=$(printf '%s\n' "$HOST_VERDI_HOME" | sed -e 's/[]\/$*.^[]/\\&/g');
 sed "s/__IPADDRESS_ETH0__/$IPADDRESS_ETH0/g" $HOME/verdi/etc/supervisord.conf.tmpl | \
   sed "s/__HYSDS_GPU_AVAILABLE__/$GPUS/g" | \
-  sed "s/__HOST_VERDI_HOME__/$HOST_VERDI_HOME/g" | \
+  sed "s/__HOST_VERDI_HOME__/$ESCAPED_HOST_VERDI_HOME/g" | \
   sed "s/__HOST_USER__/$USER/g" | \
   sed "s/__FQDN__/$FQDN/g" > $HOME/verdi/etc/supervisord.conf
 

--- a/sdscli/adapters/hysds/files/supervisord.conf.tmpl
+++ b/sdscli/adapters/hysds/files/supervisord.conf.tmpl
@@ -22,6 +22,8 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 [supervisorctl]
 serverurl=unix://%(here)s/../run/supervisor.sock
 
+{% set container_engine = CONTAINER_ENGINE -%}
+{% if container_engine == "docker" -%}
 [program:httpd]
 command=sudo /usr/sbin/apachectl -DFOREGROUND
 process_name=%(program_name)s
@@ -33,6 +35,7 @@ stdout_logfile=%(here)s/../log/%(program_name)s.log
 stdout_logfile_maxbytes=100MB
 stdout_logfile_backups=10
 startsecs=10
+{% endif %}
 
 [program:instance_stats]
 directory=/home/ops/verdi/ops/hysds/scripts

--- a/sdscli/adapters/hysds/files/supervisord.conf.tmpl
+++ b/sdscli/adapters/hysds/files/supervisord.conf.tmpl
@@ -22,8 +22,6 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 [supervisorctl]
 serverurl=unix://%(here)s/../run/supervisor.sock
 
-{% set container_engine = CONTAINER_ENGINE -%}
-{% if container_engine == "docker" -%}
 [program:httpd]
 command=sudo /usr/sbin/apachectl -DFOREGROUND
 process_name=%(program_name)s
@@ -35,7 +33,6 @@ stdout_logfile=%(here)s/../log/%(program_name)s.log
 stdout_logfile_maxbytes=100MB
 stdout_logfile_backups=10
 startsecs=10
-{% endif %}
 
 [program:instance_stats]
 directory=/home/ops/verdi/ops/hysds/scripts

--- a/sdscli/adapters/hysds/files/supervisord.conf.tmpl
+++ b/sdscli/adapters/hysds/files/supervisord.conf.tmpl
@@ -54,7 +54,9 @@ environment=HYSDS_ROOT_WORK_DIR="/data/work",
             HYSDS_DATASETS_CFG="/home/ops/verdi/etc/datasets.json",
             HYSDS_GPU_AVAILABLE="__HYSDS_GPU_AVAILABLE__",
             FACTER_ipaddress_eth0="__IPADDRESS_ETH0__",
-            FACTER_fqdn="__FQDN__"
+            FACTER_fqdn="__FQDN__",
+            HOST_VERDI_HOME="__HOST_VERDI_HOME__",
+            HOST_USER="__HOST_USER__"
 command=celery --app=hysds worker --concurrency=1 --loglevel=INFO -Q {{ queue }} -n %(program_name)s.__FQDN__ -O fair --without-mingle --without-gossip --heartbeat-interval=60
 process_name=%(program_name)s
 priority=1

--- a/sdscli/adapters/hysds/update.py
+++ b/sdscli/adapters/hysds/update.py
@@ -290,6 +290,17 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
         bar.update()
         set_bar_desc(bar, 'Updated verdi code/config')
 
+        # ship the run_podman script
+        set_bar_desc(bar, 'Updating run_verdi_podman.sh.tmpl')
+        execute(fab.rm_rf, '~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh', roles=[comp])
+        execute(fab.send_template(
+            "run_verdi_podman.sh.tmpl",
+            "~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh",
+            "~/mozart/ops/hysds-dockerfiles/verdi"),
+            roles=[comp]
+        )
+        bar.update()
+
 
 def update_metrics(conf, ndeps=False, config_only=False, comp='metrics'):
     """"Update metrics component."""
@@ -755,6 +766,17 @@ def update_verdi(conf, ndeps=False, config_only=False, comp='verdi'):
         execute(fab.send_awscreds, roles=[comp])
         bar.update()
         set_bar_desc(bar, 'Updated verdi')
+
+        # ship the run_podman script
+        set_bar_desc(bar, 'Updating run_verdi_podman.sh.tmpl')
+        execute(fab.rm_rf, '~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh', roles=[comp])
+        execute(fab.send_template(
+            "run_verdi_podman.sh.tmpl",
+            "~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh",
+            "~/mozart/ops/hysds-dockerfiles/verdi"),
+            roles=[comp]
+        )
+        bar.update()
 
 
 def update_comp(comp, conf, ndeps=False, config_only=False):

--- a/sdscli/adapters/hysds/update.py
+++ b/sdscli/adapters/hysds/update.py
@@ -293,11 +293,11 @@ def update_mozart(conf, ndeps=False, config_only=False, comp='mozart'):
         # ship the run_podman script
         set_bar_desc(bar, 'Updating run_verdi_podman.sh.tmpl')
         execute(fab.rm_rf, '~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh', roles=[comp])
-        execute(fab.send_template(
-            "run_verdi_podman.sh.tmpl",
-            "~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh",
-            "~/mozart/ops/hysds-dockerfiles/verdi"),
-            roles=[comp]
+        execute(fab.send_template,
+                "run_verdi_podman.sh.tmpl",
+                "~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh",
+                "~/mozart/ops/hysds-dockerfiles/verdi",
+                roles=[comp]
         )
         bar.update()
 
@@ -770,11 +770,11 @@ def update_verdi(conf, ndeps=False, config_only=False, comp='verdi'):
         # ship the run_podman script
         set_bar_desc(bar, 'Updating run_verdi_podman.sh.tmpl')
         execute(fab.rm_rf, '~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh', roles=[comp])
-        execute(fab.send_template(
-            "run_verdi_podman.sh.tmpl",
-            "~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh",
-            "~/mozart/ops/hysds-dockerfiles/verdi"),
-            roles=[comp]
+        execute(fab.send_template,
+                "run_verdi_podman.sh.tmpl",
+                "~/verdi/ops/hysds-dockerfiles/verdi/run_verdi_podman.sh",
+                "~/mozart/ops/hysds-dockerfiles/verdi",
+                roles=[comp]
         )
         bar.update()
 


### PR DESCRIPTION
This PR makes the following updates related to supporting the use of podman within HySDS Core:

- The sds update commands were updated to render the new `run_verdi_podman.sh` script template and to deploy it out to verdi. This script is responsible for starting up verdi under podman
- Updated the install.sh and the supervisord.conf.tmpl to render the 2 new variables that are needed in order to properly run Verdi in podman:
  - HOST_VERDI_HOME - The path to the base directory where the verdi code resides on the host.
  - HOST_USER - The name of the user on the host, which will invoke the podman commands

See these related PRs for additional info:
- https://github.com/hysds/hysds/pull/189
- https://github.com/hysds/hysds-dockerfiles/pull/11