### PR TITLE
HC-522-update: Updates that support moving away from default OPS user in the Verdi container

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/files/install.sh
+++ b/sdscli/adapters/hysds/files/install.sh
@@ -36,6 +36,7 @@ sed "s/__IPADDRESS_ETH0__/$IPADDRESS_ETH0/g" $HOME/verdi/etc/supervisord.conf.tm
   sed "s/__HYSDS_GPU_AVAILABLE__/$GPUS/g" | \
   sed "s/__HOST_VERDI_HOME__/$ESCAPED_HOST_VERDI_HOME/g" | \
   sed "s/__HOST_USER__/$USER/g" | \
+  sed "s/__HOST_UID__/$USER/g" | \
   sed "s/__FQDN__/$FQDN/g" > $HOME/verdi/etc/supervisord.conf
 
 # move creds

--- a/sdscli/adapters/hysds/files/install.sh
+++ b/sdscli/adapters/hysds/files/install.sh
@@ -2,21 +2,25 @@
 BASE_PATH=$(dirname "${BASH_SOURCE}")
 BASE_PATH=$(cd "${BASE_PATH}"; pwd)
 
-source $HOME/verdi/bin/activate
+# This is the base directory where the verdi codebase resides on the worker at the host level
+HOST_VERDI_HOME={{ HOST_VERDI_HOME or '$HOME' }}
+ESCAPED_HOST_VERDI_HOME=$(printf '%s\n' "$HOST_VERDI_HOME" | sed -e 's/[]\/$*.^[]/\\&/g');
+
+source $HOST_VERDI_HOME/verdi/bin/activate
 
 # copy hysds configs
-rm -rf $HOME/verdi/etc
-cp -rp $BASE_PATH/etc $HOME/verdi/etc
-cp -rp $HOME/verdi/ops/hysds/celeryconfig.py $HOME/verdi/etc/
+rm -rf $HOST_VERDI_HOME/verdi/etc
+cp -rp $BASE_PATH/etc $HOST_VERDI_HOME/verdi/etc
+cp -rp $HOST_VERDI_HOME/verdi/ops/hysds/celeryconfig.py $HOST_VERDI_HOME/verdi/etc/
 
 # uncomment if using SQS
-#ln -s $HOME/verdi/ops/hysds/scripts/harikiri_sqs.py $HOME/verdi/bin/harikiri.py
+#ln -s $HOST_VERDI_HOME/verdi/ops/hysds/scripts/harikiri_sqs.py $HOST_VERDI_HOME/verdi/bin/harikiri.py
 
 # uncomment to use harikiri without having to set up an SQS
-#ln -s $HOME/verdi/bin/harikiri.py
+#ln -s $HOST_VERDI_HOME/verdi/bin/harikiri.py
 
 # spot termination detector
-ln -s $HOME/verdi/ops/hysds/scripts/spot_termination_detector.py $HOME/verdi/bin/spot_termination_detector.py
+ln -s $HOST_VERDI_HOME/verdi/ops/hysds/scripts/spot_termination_detector.py $HOST_VERDI_HOME/verdi/bin/spot_termination_detector.py
 
 # detect GPUs/NVIDIA driver configuration
 GPUS=0
@@ -30,21 +34,19 @@ fi
 # write supervisord from template
 IPADDRESS_ETH0=$(/usr/sbin/ifconfig $(/usr/sbin/route | awk '/default/{print $NF}') | grep 'inet ' | sed 's/addr://' | awk '{print $2}') 
 FQDN=$IPADDRESS_ETH0
-HOST_VERDI_HOME={{ HOST_VERDI_HOME or '$HOME' }}
-ESCAPED_HOST_VERDI_HOME=$(printf '%s\n' "$HOST_VERDI_HOME" | sed -e 's/[]\/$*.^[]/\\&/g');
-sed "s/__IPADDRESS_ETH0__/$IPADDRESS_ETH0/g" $HOME/verdi/etc/supervisord.conf.tmpl | \
+sed "s/__IPADDRESS_ETH0__/$IPADDRESS_ETH0/g" $HOST_VERDI_HOME/verdi/etc/supervisord.conf.tmpl | \
   sed "s/__HYSDS_GPU_AVAILABLE__/$GPUS/g" | \
   sed "s/__HOST_VERDI_HOME__/$ESCAPED_HOST_VERDI_HOME/g" | \
   sed "s/__HOST_USER__/$USER/g" | \
   sed "s/__HOST_UID__/$USER/g" | \
-  sed "s/__FQDN__/$FQDN/g" > $HOME/verdi/etc/supervisord.conf
+  sed "s/__FQDN__/$FQDN/g" > $HOST_VERDI_HOME/verdi/etc/supervisord.conf
 
 # move creds
-rm -rf $HOME/.aws
-mv -f $BASE_PATH/creds/.aws $HOME/
-rm -rf $HOME/.boto; mv -f $BASE_PATH/creds/.boto $HOME/
-rm -rf $HOME/.s3cfg; mv -f $BASE_PATH/creds/.s3cfg $HOME/
-rm -rf $HOME/.netrc; mv -f $BASE_PATH/creds/.netrc $HOME/; chmod 600 $HOME/.netrc
+rm -rf $HOST_VERDI_HOME/.aws
+mv -f $BASE_PATH/creds/.aws $HOST_VERDI_HOME/
+rm -rf $HOST_VERDI_HOME/.boto; mv -f $BASE_PATH/creds/.boto $HOST_VERDI_HOME/
+rm -rf $HOST_VERDI_HOME/.s3cfg; mv -f $BASE_PATH/creds/.s3cfg $HOST_VERDI_HOME/
+rm -rf $HOST_VERDI_HOME/.netrc; mv -f $BASE_PATH/creds/.netrc $HOST_VERDI_HOME/; chmod 600 $HOST_VERDI_HOME/.netrc
 
 # extract beefed autoindex
 cd /data/work
@@ -54,9 +56,9 @@ tar xvfj $BASE_PATH/beefed-autoindex-open_in_new_win.tbz2
 mkdir -p /data/work/jobs
 
 # prime verdi docker image
-if [[ -f $HOME/.aws/credentials ]]; then
-  export AWS_ACCESS_KEY_ID="$(grep aws_access_key_id $HOME/.aws/credentials | head -1 | cut -d= -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-  export AWS_SECRET_ACCESS_KEY="$(grep aws_secret_access_key $HOME/.aws/credentials | head -1 | cut -d= -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+if [[ -f $HOST_VERDI_HOME/.aws/credentials ]]; then
+  export AWS_ACCESS_KEY_ID="$(grep aws_access_key_id $HOST_VERDI_HOME/.aws/credentials | head -1 | cut -d= -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  export AWS_SECRET_ACCESS_KEY="$(grep aws_secret_access_key $HOST_VERDI_HOME/.aws/credentials | head -1 | cut -d= -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
 fi
 
 export VERDI_PRIMER_IMAGE="{{ VERDI_PRIMER_IMAGE }}"
@@ -91,9 +93,9 @@ else
   echo "Logstash already exists in Docker. Will not download image"
 fi
 docker run -e HOST=${FQDN} -v /data/work/jobs:/sdswatch/jobs \
-  -v $HOME/verdi/log:/sdswatch/log \
+  -v $HOST_VERDI_HOME/verdi/log:/sdswatch/log \
   -v sdswatch_data:/usr/share/logstash/data \
-  -v $HOME/verdi/etc/sdswatch_client.conf:/usr/share/logstash/config/conf/logstash.conf \
+  -v $HOST_VERDI_HOME/verdi/etc/sdswatch_client.conf:/usr/share/logstash/config/conf/logstash.conf \
   --name=sdswatch-client -d logstash-oss:7.16.3 \
   logstash -f /usr/share/logstash/config/conf/logstash.conf --config.reload.automatic
 

--- a/sdscli/adapters/hysds/files/install.sh
+++ b/sdscli/adapters/hysds/files/install.sh
@@ -56,8 +56,9 @@ mkdir -p ${DATA_DIR}/work
 cd ${DATA_DIR}/work
 tar xvfj $BASE_PATH/beefed-autoindex-open_in_new_win.tbz2
 
-# make jobs dir
+# make jobs and tasks dir
 mkdir -p ${DATA_DIR}/work/jobs
+mkdir -p ${DATA_DIR}/work/tasks
 
 # prime verdi docker image
 if [[ -f $HOST_VERDI_HOME/.aws/credentials ]]; then

--- a/sdscli/adapters/hysds/files/supervisord.conf.tmpl
+++ b/sdscli/adapters/hysds/files/supervisord.conf.tmpl
@@ -35,8 +35,8 @@ stdout_logfile_backups=10
 startsecs=10
 
 [program:instance_stats]
-directory=/home/ops/verdi/ops/hysds/scripts
-command=/home/ops/verdi/ops/hysds/scripts/log_instance_stats.py --interval 600
+directory=/root/verdi/ops/hysds/scripts
+command=/root/verdi/ops/hysds/scripts/log_instance_stats.py --interval 600
 process_name=%(program_name)s
 priority=1
 numprocs=1
@@ -48,7 +48,7 @@ stdout_logfile_backups=10
 startsecs=10
 
 [program:{{ queue }}]
-directory=/home/ops/verdi/ops/hysds
+directory=/root/verdi/ops/hysds
 environment=HYSDS_ROOT_WORK_DIR="/data/work",
             HYSDS_CELERY_CFG="/root/verdi/etc/celeryconfig.py",
             HYSDS_DATASETS_CFG="/root/verdi/etc/datasets.json",

--- a/sdscli/adapters/hysds/files/supervisord.conf.tmpl
+++ b/sdscli/adapters/hysds/files/supervisord.conf.tmpl
@@ -20,18 +20,6 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 [supervisorctl]
 serverurl=unix://%(here)s/../run/supervisor.sock
 
-#program:httpd]
-#command=sudo /usr/sbin/apachectl -DFOREGROUND
-#process_name=%(program_name)s
-#priority=1
-#numprocs=1
-#numprocs_start=0
-#redirect_stderr=true
-#stdout_logfile=%(here)s/../log/%(program_name)s.log
-#stdout_logfile_maxbytes=100MB
-#stdout_logfile_backups=10
-#startsecs=10
-
 [program:instance_stats]
 directory=/root/verdi/ops/hysds/scripts
 command=/root/verdi/ops/hysds/scripts/log_instance_stats.py --interval 600

--- a/sdscli/adapters/hysds/files/supervisord.conf.tmpl
+++ b/sdscli/adapters/hysds/files/supervisord.conf.tmpl
@@ -3,8 +3,6 @@ file=%(here)s/../run/supervisor.sock
 
 [inet_http_server]
 port = 0.0.0.0:9001
-username = ops
-password = ops
 
 [supervisord]
 pidfile=%(here)s/../run/supervisord.pid
@@ -22,17 +20,17 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 [supervisorctl]
 serverurl=unix://%(here)s/../run/supervisor.sock
 
-[program:httpd]
-command=sudo /usr/sbin/apachectl -DFOREGROUND
-process_name=%(program_name)s
-priority=1
-numprocs=1
-numprocs_start=0
-redirect_stderr=true
-stdout_logfile=%(here)s/../log/%(program_name)s.log
-stdout_logfile_maxbytes=100MB
-stdout_logfile_backups=10
-startsecs=10
+#program:httpd]
+#command=sudo /usr/sbin/apachectl -DFOREGROUND
+#process_name=%(program_name)s
+#priority=1
+#numprocs=1
+#numprocs_start=0
+#redirect_stderr=true
+#stdout_logfile=%(here)s/../log/%(program_name)s.log
+#stdout_logfile_maxbytes=100MB
+#stdout_logfile_backups=10
+#startsecs=10
 
 [program:instance_stats]
 directory=/root/verdi/ops/hysds/scripts

--- a/sdscli/adapters/hysds/files/supervisord.conf.tmpl
+++ b/sdscli/adapters/hysds/files/supervisord.conf.tmpl
@@ -56,8 +56,7 @@ environment=HYSDS_ROOT_WORK_DIR="/data/work",
             FACTER_ipaddress_eth0="__IPADDRESS_ETH0__",
             FACTER_fqdn="__FQDN__",
             HOST_VERDI_HOME="__HOST_VERDI_HOME__",
-            HOST_USER="__HOST_USER__",
-            HOST_UID="__HOST_UID__"
+            HOST_USER="__HOST_USER__"
 command=celery --app=hysds worker --concurrency=1 --loglevel=INFO -Q {{ queue }} -n %(program_name)s.__FQDN__ -O fair --without-mingle --without-gossip --heartbeat-interval=60
 process_name=%(program_name)s
 priority=1

--- a/sdscli/adapters/hysds/files/supervisord.conf.tmpl
+++ b/sdscli/adapters/hysds/files/supervisord.conf.tmpl
@@ -50,8 +50,8 @@ startsecs=10
 [program:{{ queue }}]
 directory=/home/ops/verdi/ops/hysds
 environment=HYSDS_ROOT_WORK_DIR="/data/work",
-            HYSDS_CELERY_CFG="/home/ops/verdi/etc/celeryconfig.py",
-            HYSDS_DATASETS_CFG="/home/ops/verdi/etc/datasets.json",
+            HYSDS_CELERY_CFG="/root/verdi/etc/celeryconfig.py",
+            HYSDS_DATASETS_CFG="/root/verdi/etc/datasets.json",
             HYSDS_GPU_AVAILABLE="__HYSDS_GPU_AVAILABLE__",
             FACTER_ipaddress_eth0="__IPADDRESS_ETH0__",
             FACTER_fqdn="__FQDN__",

--- a/sdscli/adapters/hysds/files/supervisord.conf.tmpl
+++ b/sdscli/adapters/hysds/files/supervisord.conf.tmpl
@@ -56,7 +56,8 @@ environment=HYSDS_ROOT_WORK_DIR="/data/work",
             FACTER_ipaddress_eth0="__IPADDRESS_ETH0__",
             FACTER_fqdn="__FQDN__",
             HOST_VERDI_HOME="__HOST_VERDI_HOME__",
-            HOST_USER="__HOST_USER__"
+            HOST_USER="__HOST_USER__",
+            HOST_UID="__HOST_UID__"
 command=celery --app=hysds worker --concurrency=1 --loglevel=INFO -Q {{ queue }} -n %(program_name)s.__FQDN__ -O fair --without-mingle --without-gossip --heartbeat-interval=60
 process_name=%(program_name)s
 priority=1


### PR DESCRIPTION
This PR makes some updates that support moving away from the default OPS user in the Verdi container. These updates are also driven by further testing that was done with Podman in the HECC environment.

- Made install.sh more modular in that it uses `HOST_VERDI_HOME` instead of `HOME` to make the script support the use case of being able to deploy the PCM code bundle anywhere instead of always assuming it will be under $HOME
- Similiarly, `DATA_DIR` was introduced to be able to make it more modular to reference the base working directory to be anywhere instead of assuming `/data` always.
- Use `cp` instead of `mv` when deploying the AWS, .netrc, and .boto files/directories.
- supervisord.conf.tmpl was updated such that it no longer has the httpd service as a default due to JPL security in starting up webdav within Verdi. Rather, httpd service is going to be started up by the system instead.