### PR TITLE
HC-546: Add job_failed index to job_status template

### DIFF
--- a/sdscli/adapters/hysds/files/job_status.template
+++ b/sdscli/adapters/hysds/files/job_status.template
@@ -1,6 +1,7 @@
 {
   "index_patterns": [
-    "job_status*"
+    "job_status*",
+    "job_failed"
   ],
   "template": {
     "mappings": {


### PR DESCRIPTION
This PR is in conjunction with the following:

- hysds: https://github.com/hysds/hysds/pull/193
- lightweight jobs: https://github.com/hysds/lightweight-jobs/pull/34

This PR updates the existing job_status template such that it adds the `job_failed` index.

**Test**
See comments in https://hysds-core.atlassian.net/browse/HC-546