### PR TITLE
HC-563: Updated for Python 3.12 Compatibility

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -1,8 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-__version__ = "1.3.5"
+__version__ = "1.4.0"
 __url__ = "https://github.com/sdskit/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/__init__.py
+++ b/sdscli/adapters/__init__.py
@@ -1,8 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
 from sdscli.conf_utils import SettingsConf
 
 try:

--- a/sdscli/adapters/hysds/ci.py
+++ b/sdscli/adapters/hysds/ci.py
@@ -1,10 +1,6 @@
 """
 Continuous integration functions.
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 
 from future import standard_library
@@ -61,7 +57,7 @@ def add_job(args):
     else:
         repo_url = args.repo
 
-    logger.debug("repo_url: {}".format(repo_url))
+    logger.debug(f"repo_url: {repo_url}")
 
     # add jenkins job for branch or release
     if args.branch is None:

--- a/sdscli/adapters/hysds/cloud.py
+++ b/sdscli/adapters/hysds/cloud.py
@@ -1,10 +1,6 @@
 """
 SDS cloud management functions.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
 from future import standard_library
@@ -35,16 +31,16 @@ def ls(args):
 
     # check which cloud platforms configured
     for importer, mod_name, ispkg in pkgutil.iter_modules(sdscli.cloud.__path__):
-        mod = get_module('sdscli.cloud.{}.utils'.format(mod_name))
-        print(("{}: {}".format(mod_name, highlight("configured", 'green') if
-                               mod.is_configured() else highlight("unimplemented or not configured", 'red'))))
+        mod = get_module(f'sdscli.cloud.{mod_name}.utils')
+        print("{}: {}".format(mod_name, highlight("configured", 'green') if
+                               mod.is_configured() else highlight("unimplemented or not configured", 'red')))
 
 
 def asg(args):
     """ASG management functions."""
 
     # print args
-    logger.debug("In asg(): {}".format(args))
+    logger.debug(f"In asg(): {args}")
 
     # get user's SDS conf settings
     conf = SettingsConf()
@@ -65,7 +61,7 @@ def storage(args):
     """Cloud storage management functions."""
 
     # print args
-    logger.debug("In storage(): {}".format(args))
+    logger.debug(f"In storage(): {args}")
 
     # get user's SDS conf settings
     conf = SettingsConf()

--- a/sdscli/adapters/hysds/configure.py
+++ b/sdscli/adapters/hysds/configure.py
@@ -1,14 +1,8 @@
 """
 Configuration for HySDS cluster.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
-from builtins import open
-from builtins import str
 from future import standard_library
 standard_library.install_aliases()
 import os
@@ -326,10 +320,10 @@ def copy_files():
             user_file = os.path.join(files_path, os.path.basename(sds_file))
             if os.path.isdir(sds_file) and not os.path.exists(user_file):
                 shutil.copytree(sds_file, user_file)
-                logger.debug("Copying dir %s to %s" % (sds_file, user_file))
+                logger.debug(f"Copying dir {sds_file} to {user_file}")
             elif os.path.isfile(sds_file) and not os.path.exists(user_file):
                 shutil.copy(sds_file, user_file)
-                logger.debug("Copying file %s to %s" % (sds_file, user_file))
+                logger.debug(f"Copying file {sds_file} to {user_file}")
 
 
 def configure():

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -1,10 +1,6 @@
 """
 Fabric file for HySDS.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
 from sdscli.prompt_utils import highlight, blink
@@ -19,7 +15,6 @@ import json
 import yaml
 import re
 import os
-from builtins import open
 from future import standard_library
 standard_library.install_aliases()
 
@@ -225,16 +220,16 @@ def ln_sf(src, dest):
     if exists(dest):
         run('rm -rf %s' % dest)
     with cd(os.path.dirname(dest)):
-        run('ln -sf %s %s' % (src, os.path.basename(dest)))
+        run(f'ln -sf {src} {os.path.basename(dest)}')
 
 
 def cp_rp(src, dest):
-    run('cp -rp %s %s' % (src, dest))
+    run(f'cp -rp {src} {dest}')
 
 
 def cp_rp_exists(src, dest):
     if exists(src):
-        run('cp -rp %s %s' % (src, dest))
+        run(f'cp -rp {src} {dest}')
 
 
 def rm_rf(path):
@@ -340,34 +335,34 @@ def svn_co(path, svn_url):
 
 
 def svn_rev(rev, path):
-    run('svn up -r %s %s' % (rev, path))
+    run(f'svn up -r {rev} {path}')
 
 
 def ls(path):
-    run('ls -al {}'.format(path))
+    run(f'ls -al {path}')
 
 
 def cat(path):
-    run('cat {}'.format(path))
+    run(f'cat {path}')
 
 
 def tail(path):
-    run('tail {}'.format(path))
+    run(f'tail {path}')
 
 
 def tail_f(path):
-    run('tail -f {}'.format(path))
+    run(f'tail -f {path}')
 
 
 def grep(grep_str, dir_path):
     try:
-        run('grep -r %s %s' % (grep_str, dir_path))
+        run(f'grep -r {grep_str} {dir_path}')
     except:
         pass
 
 
 def chmod(perms, path):
-    run('chmod -R %s %s' % (perms, path))
+    run(f'chmod -R {perms} {path}')
 
 
 def reboot():
@@ -396,7 +391,7 @@ def untar_bz(cwd, tar_file):
 
 
 def mv(src, dest):
-    sudo('mv -f %s %s' % (src, dest))
+    sudo(f'mv -f {src} {dest}')
 
 
 def rsync(src, dest):
@@ -426,7 +421,7 @@ def stop_docker_containers():
 def systemctl(cmd, service):
     with settings(warn_only=True):
         with hide('everything'):
-            return run('sudo systemctl %s %s' % (cmd, service), pty=False)
+            return run(f'sudo systemctl {cmd} {service}', pty=False)
 
 
 def status():
@@ -435,7 +430,7 @@ def status():
         with prefix('source %s/bin/activate' % hysds_dir):
             run('supervisorctl status')
     else:
-        print((blink(highlight("Supervisord is not running on %s." % role, 'red'))))
+        print(blink(highlight("Supervisord is not running on %s." % role, 'red')))
 
 
 def ensure_venv(hysds_dir, update_bash_profile=True, system_site_packages=True, install_supervisor=True):
@@ -460,7 +455,7 @@ def ensure_venv(hysds_dir, update_bash_profile=True, system_site_packages=True, 
           context['OPS_USER'], context['OPS_USER'])
     if update_bash_profile:
         append('.bash_profile',
-               "source $HOME/{}/bin/activate".format(hysds_dir), escape=True)
+               f"source $HOME/{hysds_dir}/bin/activate", escape=True)
         append('.bash_profile',
                "export FACTER_ipaddress=$(/usr/sbin/ifconfig $(/usr/sbin/route | awk '/default/{print $NF}') | grep 'inet ' | sed 's/addr://' | awk '{print $2}')", escape=True)
 
@@ -630,7 +625,7 @@ def rabbitmq_queues_flush():
     r.raise_for_status()
     res = r.json()
     for i in res:
-        r = requests.delete('%s/%%2f/%s' % (url, i['name']),
+        r = requests.delete('{}/%2f/{}'.format(url, i['name']),
                             auth=(ctx['MOZART_RABBIT_USER'], ctx['MOZART_RABBIT_PASSWORD']))
         r.raise_for_status()
         logger.debug("Deleted queue %s." % i['name'])
@@ -777,10 +772,10 @@ def get_ci_job_info(repo, branch=None):
         raise RuntimeError("Failed to parse repo owner and name: %s" % repo)
     owner, name = match.groups()
     if branch is None:
-        job_name = "%s_container-builder_%s_%s" % (ctx['VENUE'], owner, name)
+        job_name = "{}_container-builder_{}_{}".format(ctx['VENUE'], owner, name)
         config_tmpl = 'config.xml'
     else:
-        job_name = "%s_container-builder_%s_%s_%s" % (
+        job_name = "{}_container-builder_{}_{}_{}".format(
             ctx['VENUE'], owner, name, branch)
         config_tmpl = 'config-branch.xml'
     return job_name, config_tmpl
@@ -792,7 +787,7 @@ def add_ci_job(repo, proto, branch=None, release=False):
         ctx = get_context()
         ctx['PROJECT_URL'] = repo
         ctx['BRANCH'] = branch
-        job_dir = '%s/jobs/%s' % (ctx['JENKINS_DIR'], job_name)
+        job_dir = '{}/jobs/{}'.format(ctx['JENKINS_DIR'], job_name)
         dest_file = '%s/config.xml' % job_dir
         mkdir(job_dir, None, None)
         chmod('777', job_dir)
@@ -801,10 +796,10 @@ def add_ci_job(repo, proto, branch=None, release=False):
         else:
             ctx['BRANCH_SPEC'] = "**"
         if proto in ('s3', 's3s'):
-            ctx['STORAGE_URL'] = "%s://%s/%s/" % (
+            ctx['STORAGE_URL'] = "{}://{}/{}/".format(
                 proto, ctx['S3_ENDPOINT'], ctx['CODE_BUCKET'])
         elif proto == 'gs':
-            ctx['STORAGE_URL'] = "%s://%s/%s/" % (
+            ctx['STORAGE_URL'] = "{}://{}/{}/".format(
                 proto, ctx['GS_ENDPOINT'], ctx['CODE_BUCKET'])
         elif proto in ('dav', 'davs'):
             ctx['STORAGE_URL'] = "%s://%s:%s@%s/repository/products/containers/" % \
@@ -919,7 +914,7 @@ def send_shipper_conf(node_type, log_dir, cluster_jobs, redis_ip_job_status,
 def send_logstash_jvm_options(node_type):
     ctx = get_context(node_type)
     ram_size_gb = int(get_ram_size_bytes())//1024**3
-    echo("instance RAM size: {}GB".format(ram_size_gb))
+    echo(f"instance RAM size: {ram_size_gb}GB")
     ram_size_gb_half = int(ram_size_gb//2)
     ctx['LOGSTASH_HEAP_SIZE'] = 8 if ram_size_gb_half >= 8 else ram_size_gb_half
     echo("configuring logstash heap size: {}GB".format(ctx['LOGSTASH_HEAP_SIZE']))
@@ -1086,9 +1081,9 @@ def ship_code(cwd, tar_file, encrypt=False):
     with cd(cwd):
         run('tar --exclude-vcs -cvjf %s *' % tar_file)
     if encrypt is False:
-        run('aws s3 cp %s s3://%s/' % (tar_file, ctx['CODE_BUCKET']))
+        run('aws s3 cp {} s3://{}/'.format(tar_file, ctx['CODE_BUCKET']))
     else:
-        run('aws s3 cp --sse %s s3://%s/' % (tar_file, ctx['CODE_BUCKET']))
+        run('aws s3 cp --sse {} s3://{}/'.format(tar_file, ctx['CODE_BUCKET']))
 
 
 ##########################
@@ -1101,29 +1096,29 @@ def send_awscreds(suffix=None):
         boto_file = '.boto'
         s3cfg_file = '.s3cfg'
     else:
-        aws_dir = '.aws{}'.format(suffix)
-        boto_file = '.boto{}'.format(suffix)
-        s3cfg_file = '.s3cfg{}'.format(suffix)
+        aws_dir = f'.aws{suffix}'
+        boto_file = f'.boto{suffix}'
+        s3cfg_file = f'.s3cfg{suffix}'
     if exists(aws_dir):
-        run('rm -rf {}'.format(aws_dir))
+        run(f'rm -rf {aws_dir}')
     mkdir(aws_dir, context['OPS_USER'], context['OPS_USER'])
-    run('chmod 700 {}'.format(aws_dir))
-    upload_template('aws_config', '{}/config'.format(aws_dir), use_jinja=True, context=ctx,
+    run(f'chmod 700 {aws_dir}')
+    upload_template('aws_config', f'{aws_dir}/config', use_jinja=True, context=ctx,
                     template_dir=get_user_files_path())
     if ctx['AWS_ACCESS_KEY'] not in (None, ""):
-        upload_template('aws_credentials', '{}/credentials'.format(aws_dir), use_jinja=True, context=ctx,
+        upload_template('aws_credentials', f'{aws_dir}/credentials', use_jinja=True, context=ctx,
                         template_dir=get_user_files_path())
-    run('chmod 600 {}/*'.format(aws_dir))
+    run(f'chmod 600 {aws_dir}/*')
     if exists(boto_file):
-        run('rm -rf {}'.format(boto_file))
+        run(f'rm -rf {boto_file}')
     upload_template('boto', boto_file, use_jinja=True, context=ctx,
                     template_dir=get_user_files_path())
-    run('chmod 600 {}'.format(boto_file))
+    run(f'chmod 600 {boto_file}')
     if exists(s3cfg_file):
-        run('rm -rf {}'.format(s3cfg_file))
+        run(f'rm -rf {s3cfg_file}')
     upload_template('s3cfg', s3cfg_file, use_jinja=True, context=ctx,
                     template_dir=get_user_files_path())
-    run('chmod 600 {}'.format(s3cfg_file))
+    run(f'chmod 600 {s3cfg_file}')
 
 
 ##########################
@@ -1156,13 +1151,13 @@ def ship_style(bucket=None, encrypt=False):
     upload_template('s3-bucket-listing.html.tmpl', index_file, use_jinja=True,
                     context=ctx, template_dir=get_user_files_path())
     if encrypt is False:
-        run('aws s3 cp %s s3://%s/index.html' % (index_file, bucket))
-        run('aws s3 cp %s s3://%s/' % (list_js, bucket))
-        run('aws s3 sync %s s3://%s/index-style' % (index_style, bucket))
+        run(f'aws s3 cp {index_file} s3://{bucket}/index.html')
+        run(f'aws s3 cp {list_js} s3://{bucket}/')
+        run(f'aws s3 sync {index_style} s3://{bucket}/index-style')
     else:
-        run('aws s3 cp --sse %s s3://%s/index.html' % (index_file, bucket))
-        run('aws s3 cp --sse %s s3://%s/' % (list_js, bucket))
-        run('aws s3 sync --sse %s s3://%s/index-style' % (index_style, bucket))
+        run(f'aws s3 cp --sse {index_file} s3://{bucket}/index.html')
+        run(f'aws s3 cp --sse {list_js} s3://{bucket}/')
+        run(f'aws s3 sync --sse {index_style} s3://{bucket}/index-style')
 
 
 ##########################
@@ -1172,7 +1167,7 @@ def create_zip(zip_dir, zip_file):
     if exists(zip_file):
         run('rm -rf %s' % zip_file)
     with cd(zip_dir):
-        run('zip -r -9 {} *'.format(zip_file))
+        run(f'zip -r -9 {zip_file} *')
 
 
 ##########################
@@ -1189,21 +1184,21 @@ def init_sdsadm():
     role, hysds_dir, hostname = resolve_role()
     with cd(os.path.join(hysds_dir, 'ops', 'sdsadm')):
         with prefix('source ~/%s/bin/activate' % hysds_dir):
-            run("./sdsadm init {} -f".format(role))
+            run(f"./sdsadm init {role} -f")
 
 
 def start_sdsadm(release):
     role, hysds_dir, hostname = resolve_role()
     with cd(os.path.join(hysds_dir, 'ops', 'sdsadm')):
         with prefix('source ~/%s/bin/activate' % hysds_dir):
-            run("./sdsadm -r {} start {} -d".format(release, role))
+            run(f"./sdsadm -r {release} start {role} -d")
 
 
 def stop_sdsadm():
     role, hysds_dir, hostname = resolve_role()
     with cd(os.path.join(hysds_dir, 'ops', 'sdsadm')):
         with prefix('source ~/%s/bin/activate' % hysds_dir):
-            run("./sdsadm stop {}".format(role))
+            run(f"./sdsadm stop {role}")
 
 
 def logs_sdsadm(follow=False):
@@ -1211,23 +1206,23 @@ def logs_sdsadm(follow=False):
     with cd(os.path.join(hysds_dir, 'ops', 'sdsadm')):
         with prefix('source ~/%s/bin/activate' % hysds_dir):
             if follow:
-                run("./sdsadm logs {} -f".format(role))
+                run(f"./sdsadm logs {role} -f")
             else:
-                run("./sdsadm logs {}".format(role))
+                run(f"./sdsadm logs {role}")
 
 
 def ps_sdsadm():
     role, hysds_dir, hostname = resolve_role()
     with cd(os.path.join(hysds_dir, 'ops', 'sdsadm')):
         with prefix('source ~/%s/bin/activate' % hysds_dir):
-            run("./sdsadm ps {}".format(role))
+            run(f"./sdsadm ps {role}")
 
 
 def run_sdsadm(cmd):
     role, hysds_dir, hostname = resolve_role()
     with cd(os.path.join(hysds_dir, 'ops', 'sdsadm')):
         with prefix('source ~/%s/bin/activate' % hysds_dir):
-            run("./sdsadm run {} {}".format(role, cmd))
+            run(f"./sdsadm run {role} {cmd}")
 
 
 def conf_sdsadm(tmpl, dest, shared=False):

--- a/sdscli/adapters/hysds/files/cluster.py
+++ b/sdscli/adapters/hysds/files/cluster.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 from sdscli.adapters.hysds.fabfile import *

--- a/sdscli/adapters/hysds/files/netrc.mozart
+++ b/sdscli/adapters/hysds/files/netrc.mozart
@@ -1,3 +1,4 @@
 machine {{ MOZART_RABBIT_PVT_IP }} login {{ MOZART_RABBIT_USER }} password {{ MOZART_RABBIT_PASSWORD }}
 macdef init
- 
+{% raw %}
+{% endraw %}

--- a/sdscli/adapters/hysds/files/watch_supervisord_services.py
+++ b/sdscli/adapters/hysds/files/watch_supervisord_services.py
@@ -6,7 +6,7 @@ import argparse
 import time
 import re
 from subprocess import check_output
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 
 # regexes
@@ -46,7 +46,7 @@ def daemon(check, host, name, source_type, source_id, services):
                 except Exception as e:
                     output = str(e.output)
                 lines.extend([i.strip() for i in output.split("\n")])
-        timestamp = datetime.now(UTC).replace(tzinfo=None).isoformat()
+        timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
         for line in lines:
             if m := RUNNING_RE.search(line):
                 g = m.groupdict()

--- a/sdscli/adapters/hysds/files/watch_supervisord_services.py
+++ b/sdscli/adapters/hysds/files/watch_supervisord_services.py
@@ -31,7 +31,7 @@ def daemon(check, host, name, source_type, source_id, services):
         if services is None:
             try:
                 output = check_output(
-                    ["supervisorctl", "status"], universal_newlines=True
+                    ["supervisorctl", "status"], text=True
                 )
             except Exception as e:
                 output = str(e.output)
@@ -41,7 +41,7 @@ def daemon(check, host, name, source_type, source_id, services):
             for service in services:
                 try:
                     output = check_output(
-                        ["supervisorctl", "status", service], universal_newlines=True
+                        ["supervisorctl", "status", service], text=True
                     )
                 except Exception as e:
                     output = str(e.output)

--- a/sdscli/adapters/hysds/files/watch_supervisord_services.py
+++ b/sdscli/adapters/hysds/files/watch_supervisord_services.py
@@ -6,7 +6,7 @@ import argparse
 import time
 import re
 from subprocess import check_output
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 # regexes
@@ -46,7 +46,7 @@ def daemon(check, host, name, source_type, source_id, services):
                 except Exception as e:
                     output = str(e.output)
                 lines.extend([i.strip() for i in output.split("\n")])
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(UTC).replace(tzinfo=None).isoformat()
         for line in lines:
             if m := RUNNING_RE.search(line):
                 g = m.groupdict()

--- a/sdscli/adapters/hysds/files/watch_systemd_services.py
+++ b/sdscli/adapters/hysds/files/watch_systemd_services.py
@@ -29,7 +29,7 @@ def daemon(check, host, name, source_type, source_id, services):
         for service in services:
             output = check_output(
                 ["sudo", "systemctl", "show", "--no-page", service],
-                universal_newlines=True,
+                text=True,
             )
             if m := ACTIVESTATE_RE.search(output):
                 active_state = m.group(1)

--- a/sdscli/adapters/hysds/files/watch_systemd_services.py
+++ b/sdscli/adapters/hysds/files/watch_systemd_services.py
@@ -6,7 +6,7 @@ import argparse
 import time
 import re
 from subprocess import check_output
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 # regexes
@@ -39,7 +39,7 @@ def daemon(check, host, name, source_type, source_id, services):
                 active_enter_ts = m.group(1)
             if m := WATCHDOG_TS_RE.search(output):
                 watchdog_ts = m.group(1)
-            timestamp = datetime.utcnow().isoformat()
+            timestamp = datetime.now(UTC).replace(tzinfo=None).isoformat()
             print(
                 f'{timestamp}, {host}, systemd, status, systemd.service={service} systemd.ActiveState={active_state} systemd.SubState={sub_state} systemd.ActiveStateTimestamp="{active_enter_ts}" systemd.WatchdogTimestamp="{watchdog_ts}"',
                 flush=True,

--- a/sdscli/adapters/hysds/files/watch_systemd_services.py
+++ b/sdscli/adapters/hysds/files/watch_systemd_services.py
@@ -6,7 +6,7 @@ import argparse
 import time
 import re
 from subprocess import check_output
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 
 # regexes
@@ -39,7 +39,7 @@ def daemon(check, host, name, source_type, source_id, services):
                 active_enter_ts = m.group(1)
             if m := WATCHDOG_TS_RE.search(output):
                 watchdog_ts = m.group(1)
-            timestamp = datetime.now(UTC).replace(tzinfo=None).isoformat()
+            timestamp = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
             print(
                 f'{timestamp}, {host}, systemd, status, systemd.service={service} systemd.ActiveState={active_state} systemd.SubState={sub_state} systemd.ActiveStateTimestamp="{active_enter_ts}" systemd.WatchdogTimestamp="{watchdog_ts}"',
                 flush=True,

--- a/sdscli/adapters/hysds/orch.py
+++ b/sdscli/adapters/hysds/orch.py
@@ -1,10 +1,6 @@
 """
 SDS container orchestration functions.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
 from . import fabfile as fab
@@ -130,7 +126,7 @@ def init_metrics(conf, comp='metrics'):
 
         # rsync sdsadm
         set_bar_desc(bar, 'Syncing sdsadm')
-        execute(fab.rm_rf, '~/{}/ops/sdsadm'.format(comp), roles=[comp])
+        execute(fab.rm_rf, f'~/{comp}/ops/sdsadm', roles=[comp])
         execute(fab.rsync_sdsadm, roles=[comp])
         bar.update()
 
@@ -260,11 +256,11 @@ def init_comp(comp, conf):
 
     with tqdm(total=len(comps)) as bar:
         for c in comps:
-            set_bar_desc(bar, 'Initializing {}'.format(c))
-            globals()["init_{}".format(c)](conf)
+            set_bar_desc(bar, f'Initializing {c}')
+            globals()[f"init_{c}"](conf)
             bar.update()
-            set_bar_desc(bar, 'Initialized {}'.format(c))
-        set_bar_desc(bar, "Initialized {}".format(comp))
+            set_bar_desc(bar, f'Initialized {c}')
+        set_bar_desc(bar, f"Initialized {comp}")
         print("")
 
 
@@ -274,7 +270,7 @@ def init(comp, debug=False, force=False):
     # prompt user
     if not force:
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Initializing component[s]: {}. Continue [y/n]: ".format(comp)), (Token, " ")],
+                                                    f"Initializing component[s]: {comp}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0
@@ -302,10 +298,10 @@ def start_comp(comp, release, conf):
         comps = [comp]
     with tqdm(total=len(comps)) as bar:
         for c in comps:
-            set_bar_desc(bar, 'Starting {} ({})'.format(c, release))
+            set_bar_desc(bar, f'Starting {c} ({release})')
             execute(fab.start_sdsadm, release, roles=[c])
             bar.update()
-            set_bar_desc(bar, 'Started {} ({})'.format(c, release))
+            set_bar_desc(bar, f'Started {c} ({release})')
         set_bar_desc(bar, "Started all")
         print("")
 
@@ -316,7 +312,7 @@ def start(comp, release, debug=False, force=False):
     # prompt user
     if not force:
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Starting component[s]: {}. Continue [y/n]: ".format(comp)), (Token, " ")],
+                                                    f"Starting component[s]: {comp}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0
@@ -340,10 +336,10 @@ def stop_comp(comp, conf):
         comps = [comp]
     with tqdm(total=len(comps)) as bar:
         for c in comps:
-            set_bar_desc(bar, 'Stopping {}'.format(c))
+            set_bar_desc(bar, f'Stopping {c}')
             execute(fab.stop_sdsadm, roles=[c])
             bar.update()
-            set_bar_desc(bar, 'Stopped {}'.format(c))
+            set_bar_desc(bar, f'Stopped {c}')
         set_bar_desc(bar, "Stopped all")
         print("")
 
@@ -354,7 +350,7 @@ def stop(comp, debug=False, force=False):
     # prompt user
     if not force:
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Stopping component[s]: {}. Continue [y/n]: ".format(comp)), (Token, " ")],
+                                                    f"Stopping component[s]: {comp}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0

--- a/sdscli/adapters/hysds/pkg.py
+++ b/sdscli/adapters/hysds/pkg.py
@@ -1,9 +1,4 @@
 """SDS package management functions."""
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from builtins import open
 from datetime import datetime
 from future import standard_library
 standard_library.install_aliases()
@@ -36,7 +31,7 @@ def ls(args):
 
     for hit in hits:
         logger.debug(json.dumps(hit, indent=2))
-        print((hit['_id']))
+        print(hit['_id'])
     return
 
 
@@ -47,7 +42,7 @@ def export(args):
     # query for container
     cont = mozart_es.get_by_id(index=CONTAINERS_INDEX, id=cont_id, ignore=404)
     if cont['found'] is False:
-        logger.error("SDS package id {} not found.".format(cont_id))
+        logger.error(f"SDS package id {cont_id} not found.")
         return 1
 
     cont_info = cont['_source']
@@ -60,7 +55,7 @@ def export(args):
     logger.debug("export_dir: %s" % export_dir)
 
     if os.path.exists(export_dir):  # if directory exists, stop
-        logger.error("SDS package export directory {} exists. Not continuing.".format(export_dir))
+        logger.error(f"SDS package export directory {export_dir} exists. Not continuing.")
         return 1
 
     validate_dir(export_dir)  # create export directory
@@ -85,7 +80,7 @@ def export(args):
         query = {
             "query": {
                 "query_string": {
-                    "query": "container:\"{}\"".format(cont_id)
+                    "query": f"container:\"{cont_id}\""
                 }
             }
         }
@@ -178,7 +173,7 @@ def export(args):
         json.dump(manifest, f, indent=2, sort_keys=True)
 
     # tar up hysds package
-    tar_file = os.path.join(outdir, "{}.tar".format(export_name))
+    tar_file = os.path.join(outdir, f"{export_name}.tar")
     with tarfile.open(tar_file, "w") as tar:
         tar.add(export_dir, arcname=os.path.relpath(export_dir, outdir))
 
@@ -218,7 +213,7 @@ def import_pkg(args):
 
     # get code bucket
     code_bucket = conf.get('CODE_BUCKET')
-    code_bucket_url = "s3://%s/%s" % (conf.get('S3_ENDPOINT'), code_bucket)
+    code_bucket_url = "s3://{}/{}".format(conf.get('S3_ENDPOINT'), code_bucket)
     logger.debug("code_bucket: %s" % code_bucket)
     logger.debug("code_bucket_url: %s" % code_bucket_url)
 
@@ -244,7 +239,7 @@ def import_pkg(args):
             else:
                 # upload container
                 dep_img = os.path.join(export_dir, d['container_image_url'])
-                d['container_image_url'] = "%s/%s" % (code_bucket_url, d['container_image_url'])
+                d['container_image_url'] = "{}/{}".format(code_bucket_url, d['container_image_url'])
                 if args.skip_include_dependency_images:
                     logger.info(f"Skipping upload of dependency image: {dep_img}.")
                 else:
@@ -288,11 +283,11 @@ def rm(args):
 
     cont_info = mozart_es.get_by_id(index=CONTAINERS_INDEX, id=cont_id, ignore=404)  # query for container
     if cont_info['found'] is False:
-        logger.error("SDS package id {} not found.".format(cont_id))
+        logger.error(f"SDS package id {cont_id} not found.")
         return 1
 
     cont_info = cont_info['_source']
-    logger.debug("cont_info: {}".format(json.dumps(cont_info, indent=2)))
+    logger.debug(f"cont_info: {json.dumps(cont_info, indent=2)}")
 
     rmall(cont_info['url'])  # delete container from code bucket and ES
 

--- a/sdscli/adapters/hysds/pkg.py
+++ b/sdscli/adapters/hysds/pkg.py
@@ -14,6 +14,7 @@ from sdscli.os_utils import validate_dir, normpath
 
 from osaka.main import get, put, rmall
 from hysds.es_util import get_mozart_es
+from hysds.utils import datetime_iso_naive
 
 CONTAINERS_INDEX = "containers"
 JOB_SPECS_INDEX = "job_specs"
@@ -264,7 +265,7 @@ def import_pkg(args):
     # index user_rules to ES
     for component in (('mozart', USER_RULES_MOZART_INDEX), ('grq', USER_RULES_GRQ_INDEX)):
         for rule in manifest.get('user_rules', {}).get(component[0], []):
-            now = datetime.utcnow().isoformat() + 'Z'
+            now = datetime_iso_naive() + 'Z'
 
             if not rule.get('creation_time', None):
                 rule['creation_time'] = now

--- a/sdscli/adapters/hysds/reset.py
+++ b/sdscli/adapters/hysds/reset.py
@@ -1,10 +1,6 @@
 """
 Reset components for HySDS.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
 from future import standard_library
@@ -194,7 +190,7 @@ def reset(comp, debug=False, force=False):
     # prompt user
     if not force:
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Resetting component[s]: {}. Continue [y/n]: ".format(comp)), (Token, " ")],
+                                                    f"Resetting component[s]: {comp}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0

--- a/sdscli/adapters/hysds/rules.py
+++ b/sdscli/adapters/hysds/rules.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from sdscli.log_utils import logger
 from sdscli.os_utils import validate_dir, normpath
 from hysds.es_util import get_mozart_es
+from hysds.utils import datetime_iso_naive
 
 USER_RULES_MOZART = 'user_rules-mozart'
 USER_RULES_GRQ = 'user_rules-grq'
@@ -61,7 +62,7 @@ def import_rules(args):
     logger.debug(f"rules: {json.dumps(rules_file, indent=2, sort_keys=True)}")
 
     for rule in user_rules['mozart']:
-        now = datetime.utcnow().isoformat() + 'Z'
+        now = datetime_iso_naive() + 'Z'
 
         if not rule.get('creation_time', None):
             rule['creation_time'] = now
@@ -72,7 +73,7 @@ def import_rules(args):
         logger.debug(result)
 
     for rule in user_rules['grq']:
-        now = datetime.utcnow().isoformat() + 'Z'
+        now = datetime_iso_naive() + 'Z'
 
         if not rule.get('creation_time', None):
             rule['creation_time'] = now

--- a/sdscli/adapters/hysds/rules.py
+++ b/sdscli/adapters/hysds/rules.py
@@ -1,9 +1,4 @@
 """SDS user rules management functions."""
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import open
 from future import standard_library
 standard_library.install_aliases()
 
@@ -33,11 +28,11 @@ def export(args):
     rules['grq'] = [rule['_source'] for rule in grq_rules]
     logger.debug('%d grq user rules found' % len(grq_rules))
 
-    logger.debug("rules: {}".format(json.dumps(rules, indent=2)))
+    logger.debug(f"rules: {json.dumps(rules, indent=2)}")
 
     outfile = normpath(args.outfile)  # set export directory
     export_dir = os.path.dirname(outfile)
-    logger.debug("export_dir: {}".format(export_dir))
+    logger.debug(f"export_dir: {export_dir}")
 
     validate_dir(export_dir)  # create export directory
 
@@ -55,15 +50,15 @@ def import_rules(args):
     """
 
     rules_file = normpath(args.file)  # user rules JSON file
-    logger.debug("rules_file: {}".format(rules_file))
+    logger.debug(f"rules_file: {rules_file}")
 
     if not os.path.isfile(rules_file):
-        logger.error("HySDS user rules file {} doesn't exist.".format(rules_file))
+        logger.error(f"HySDS user rules file {rules_file} doesn't exist.")
         return 1
 
     with open(rules_file) as f:
         user_rules = json.load(f)  # read in user rules
-    logger.debug("rules: {}".format(json.dumps(rules_file, indent=2, sort_keys=True)))
+    logger.debug(f"rules: {json.dumps(rules_file, indent=2, sort_keys=True)}")
 
     for rule in user_rules['mozart']:
         now = datetime.utcnow().isoformat() + 'Z'

--- a/sdscli/adapters/hysds/start.py
+++ b/sdscli/adapters/hysds/start.py
@@ -1,10 +1,6 @@
 """
 Start components for HySDS.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
 from . import fabfile as fab
@@ -145,7 +141,7 @@ def start(comp, debug=False, force=False):
     # prompt user
     if not force:
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Starting component[s]: {}. Continue [y/n]: ".format(comp)), (Token, " ")],
+                                                    f"Starting component[s]: {comp}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0

--- a/sdscli/adapters/hysds/start_tps.py
+++ b/sdscli/adapters/hysds/start_tps.py
@@ -1,10 +1,6 @@
 """
 Start TPS components for HySDS.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
 from future import standard_library
@@ -146,7 +142,7 @@ def start(comp, debug=False, force=False):
     # prompt user
     if not force:
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Starting TPS on component[s]: {}. Continue [y/n]: ".format(comp)), (Token, " ")],
+                                                    f"Starting TPS on component[s]: {comp}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0

--- a/sdscli/adapters/hysds/status.py
+++ b/sdscli/adapters/hysds/status.py
@@ -1,10 +1,6 @@
 """
 Status of HySDS components.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
 from future import standard_library
@@ -54,7 +50,7 @@ def print_rabbitmq_status(user, password, host):
         user=user,
         password=password,
         host=host)
-    logger.debug("amqp_url: {}".format(amqp_url))
+    logger.debug(f"amqp_url: {amqp_url}")
     try:
         conn = kombu.Connection(amqp_url)
         conn.ensure_connection(max_retries=3)
@@ -106,9 +102,9 @@ def print_es_status(host, component):
         pass
 
     if status == 'active':
-        print(("{}: {}".format(service, highlight(status.upper()))))
+        print(f"{service}: {highlight(status.upper())}")
     else:
-        print(("{}: {}".format(service, blink(highlight(status.upper(), 'red')))))
+        print("{}: {}".format(service, blink(highlight(status.upper(), 'red'))))
 
 
 def print_http_status(server, url):
@@ -117,9 +113,9 @@ def print_http_status(server, url):
     try:
         r = requests.get(url, verify=False)
         r.raise_for_status()
-        print(("{}: {}".format(server, highlight("RUNNING"))))
+        print("{}: {}".format(server, highlight("RUNNING")))
     except Exception as e:
-        print(("{}: {}".format(server, blink(highlight("NOT RUNNING", 'red', True)))))
+        print("{}: {}".format(server, blink(highlight("NOT RUNNING", 'red', True))))
         print(e)
 
 
@@ -130,12 +126,12 @@ def print_service_status(service, ret, debug=False):
     status_match = re.search(r'Active:\s+(.+?)\s+', stdout)
     if not status_match:
         raise RuntimeError(
-            "Failed to extract status of {} from stdout:\n{}".format(service, stdout))
+            f"Failed to extract status of {service} from stdout:\n{stdout}")
     status = status_match.group(1)
     if status == 'active':
-        print(("{}: {}".format(service, highlight(status.upper()))))
+        print(f"{service}: {highlight(status.upper())}")
     else:
-        print(("{}: {}".format(service, blink(highlight(status.upper(), 'red')))))
+        print("{}: {}".format(service, blink(highlight(status.upper(), 'red'))))
     if debug:
         print(stdout)
 

--- a/sdscli/adapters/hysds/stop.py
+++ b/sdscli/adapters/hysds/stop.py
@@ -1,10 +1,6 @@
 """
 Stop components for HySDS.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
 from future import standard_library
@@ -149,7 +145,7 @@ def stop(comp, debug=False, force=False):
     # prompt user
     if not force:
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Stopping component[s]: {}. Continue [y/n]: ".format(comp)), (Token, " ")],
+                                                    f"Stopping component[s]: {comp}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0

--- a/sdscli/adapters/hysds/stop_tps.py
+++ b/sdscli/adapters/hysds/stop_tps.py
@@ -1,10 +1,6 @@
 """
 Stop TPS components for HySDS.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 
 
 from future import standard_library
@@ -146,7 +142,7 @@ def stop(comp, debug=False, force=False):
     # prompt user
     if not force:
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Stopping TPS on component[s]: {}. Continue [y/n]: ".format(comp)), (Token, " ")],
+                                                    f"Stopping TPS on component[s]: {comp}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0

--- a/sdscli/adapters/hysds/update.py
+++ b/sdscli/adapters/hysds/update.py
@@ -1,10 +1,6 @@
 """
 Update components for HySDS.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
@@ -821,7 +817,7 @@ def update(comp, debug=False, force=False, ndeps=False, config_only=False):
     # prompt user
     if not force:
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Updating component[s]: {}. Continue [y/n]: ".format(comp)), (Token, " ")],
+                                                    f"Updating component[s]: {comp}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0
@@ -854,7 +850,7 @@ def ship_verdi(conf, encrypt=False, comp='mozart'):
         # iterate over queues
         for queue in queues:
 
-            set_bar_desc(bar, 'Shipping {} queue'.format(queue))
+            set_bar_desc(bar, f'Shipping {queue} queue')
 
             # progress bar
             with tqdm(total=5) as queue_bar:
@@ -910,9 +906,9 @@ def ship_verdi(conf, encrypt=False, comp='mozart'):
                 execute(fab.mkdir, '~/code_configs',
                         'ops', 'ops', roles=[comp])
                 execute(
-                    fab.rm_rf, '~/code_configs/{}-{}.tbz2'.format(queue, venue), roles=[comp])
+                    fab.rm_rf, f'~/code_configs/{queue}-{venue}.tbz2', roles=[comp])
                 execute(fab.ship_code, '~/verdi/ops',
-                        '~/code_configs/{}-{}.tbz2'.format(queue, venue), encrypt, roles=[comp])
+                        f'~/code_configs/{queue}-{venue}.tbz2', encrypt, roles=[comp])
                 queue_bar.update()
             bar.update()
         set_bar_desc(bar, 'Finished shipping')
@@ -1002,7 +998,7 @@ def kibana(job_type, debug=False, force=False):
 
     if not force:  # prompt user
         cont = prompt(get_prompt_tokens=lambda x: [(Token.Alert,
-                                                    "Updating Kibana: {}. Continue [y/n]: ".format(job_type)), (Token, " ")],
+                                                    f"Updating Kibana: {job_type}. Continue [y/n]: "), (Token, " ")],
                       validator=YesNoValidator(), style=prompt_style) == 'y'
         if not cont:
             return 0

--- a/sdscli/adapters/sdskit/configure.py
+++ b/sdscli/adapters/sdskit/configure.py
@@ -1,8 +1,4 @@
 """Configuration for SDSKit cluster."""
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 

--- a/sdscli/cloud/aws/asg.py
+++ b/sdscli/cloud/aws/asg.py
@@ -1,11 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-
-
-from builtins import int
-from builtins import map
 from future import standard_library
 standard_library.install_aliases()
 import os
@@ -43,7 +35,7 @@ def ls(args, conf):
     """List all Autoscaling groups."""
 
     for asg in get_asgs():
-        print((asg['AutoScalingGroupName']))
+        print(asg['AutoScalingGroupName'])
 
 
 def prompt_image(images):
@@ -52,7 +44,7 @@ def prompt_image(images):
     ids = list(images.keys())
     pt = [(Token, "Current verdi AMIs are:\n\n")]
     for i, x in enumerate(ids):
-        pt.append((Token.Param, "{}".format(i)))
+        pt.append((Token.Param, f"{i}"))
         pt.append(
             (Token, ". {} - {} ({})\n".format(images[x]['Name'], x, images[x]['CreationDate'])))
     pt.append((Token, "\nSelect verdi AMI to use for launch configurations: "))
@@ -62,7 +54,7 @@ def prompt_image(images):
         try:
             return ids[sel]
         except IndexError:
-            print(("Invalid selection: {}".format(sel)))
+            print(f"Invalid selection: {sel}")
 
 
 def prompt_keypair(keypairs):
@@ -71,8 +63,8 @@ def prompt_keypair(keypairs):
     ids = list(keypairs.keys())
     pt = [(Token, "Current key pairs are:\n\n")]
     for i, x in enumerate(ids):
-        pt.append((Token.Param, "{}".format(i)))
-        pt.append((Token, ". {}\n".format(x)))
+        pt.append((Token.Param, f"{i}"))
+        pt.append((Token, f". {x}\n"))
     pt.append((Token, "\nSelect key pair to use for launch configurations: "))
     while True:
         sel = int(prompt(get_prompt_tokens=lambda x: pt, style=prompt_style,
@@ -80,7 +72,7 @@ def prompt_keypair(keypairs):
         try:
             return ids[sel]
         except IndexError:
-            print(("Invalid selection: {}".format(sel)))
+            print(f"Invalid selection: {sel}")
 
 
 def prompt_roles(roles):
@@ -89,8 +81,8 @@ def prompt_roles(roles):
     ids = list(roles.keys())
     pt = [(Token, "Current roles are:\n\n")]
     for i, x in enumerate(ids):
-        pt.append((Token.Param, "{}".format(i)))
-        pt.append((Token, ". {}\n".format(x)))
+        pt.append((Token.Param, f"{i}"))
+        pt.append((Token, f". {x}\n"))
     pt.append((Token, "\nSelect role to use for launch configurations: "))
     while True:
         sel = int(prompt(get_prompt_tokens=lambda x: pt, style=prompt_style,
@@ -98,7 +90,7 @@ def prompt_roles(roles):
         try:
             return ids[sel]
         except IndexError:
-            print(("Invalid selection: {}".format(sel)))
+            print(f"Invalid selection: {sel}")
 
 
 def prompt_secgroup(sgs, desc=None):
@@ -109,7 +101,7 @@ def prompt_secgroup(sgs, desc=None):
     ids = list(sgs.keys())
     pt = [(Token, "Current security groups are:\n\n")]
     for i, x in enumerate(ids):
-        pt.append((Token.Param, "{}".format(i)))
+        pt.append((Token.Param, f"{i}"))
         pt.append(
             (Token, ". {} - {} - {}\n".format(sgs[x]['VpcId'], sgs[x]['GroupName'], x)))
     pt.append((Token, desc))
@@ -124,14 +116,14 @@ def prompt_secgroup(sgs, desc=None):
                 sgs_ids.add(ids[sel])
                 vpc_ids.add(sgs[ids[sel]]['VpcId'])
             except IndexError:
-                print(("Invalid selection: {}".format(sel)))
+                print(f"Invalid selection: {sel}")
                 invalid = True
                 break
         if invalid:
             continue
         if len(vpc_ids) > 1:
-            print(("Invalid selections. Security groups from multiple VPC IDs selected: {}".format(
-                list(vpc_ids))))
+            print("Invalid selections. Security groups from multiple VPC IDs selected: {}".format(
+                list(vpc_ids)))
             continue
         return list(sgs_ids), list(vpc_ids)[0]
 
@@ -149,15 +141,15 @@ def create(args, conf):
 
     # get current autoscaling groups
     cur_asgs = {i['AutoScalingGroupName']: i for i in get_asgs(c)}
-    logger.debug("cur_asgs: {}".format(pformat(cur_asgs)))
+    logger.debug(f"cur_asgs: {pformat(cur_asgs)}")
 
     # get current key pairs
     cur_keypairs = {i['KeyName']: i for i in get_keypairs(ec2)}
-    logger.debug("cur_keypairs: {}".format(pformat(cur_keypairs)))
+    logger.debug(f"cur_keypairs: {pformat(cur_keypairs)}")
 
     # get roles
     cur_roles = {i['RoleName']: i for i in get_roles()}
-    logger.debug("cur_roles: {}".format(pformat(cur_roles)))
+    logger.debug(f"cur_roles: {pformat(cur_roles)}")
 
     # get current AMIs
     verdi_re = re.compile(r'(?:verdi|autoscale)', re.IGNORECASE)
@@ -165,26 +157,26 @@ def create(args, conf):
                               [x for x in sorted(get_images(c=ec2, Filters=[{'Name': 'is-public', 'Values': ['false']}]),
                                                  key=itemgetter('CreationDate')) if verdi_re.search(x['Name'])]
                               ])
-    logger.debug("cur_images: {}".format(json.dumps(cur_images, indent=2)))
-    logger.debug("cur_images.keys(): {}".format(list(cur_images.keys())))
+    logger.debug(f"cur_images: {json.dumps(cur_images, indent=2)}")
+    logger.debug(f"cur_images.keys(): {list(cur_images.keys())}")
 
     # get current security groups
     cur_sgs = {i['GroupId']: i for i in get_sgs(ec2)}
-    logger.debug("cur_sgs: {}".format(pformat(cur_sgs)))
+    logger.debug(f"cur_sgs: {pformat(cur_sgs)}")
 
     # prompt for verdi AMI
     if 'AMI' in asg_cfg:
         ami = asg_cfg['AMI']
     else:
         ami = prompt_image(cur_images)
-    logger.debug("AMI ID: {}".format(ami))
+    logger.debug(f"AMI ID: {ami}")
 
     # prompt for key pair
     if 'KEYPAIR' in asg_cfg:
         keypair = asg_cfg['KEYPAIR']
     else:
         keypair = prompt_keypair(cur_keypairs)
-    logger.debug("key pair: {}".format(keypair))
+    logger.debug(f"key pair: {keypair}")
 
     # prompt for roles
     use_role = False
@@ -193,13 +185,13 @@ def create(args, conf):
     else:
         use_role = prompt(get_prompt_tokens=lambda x: [(Token, "Do you want to use instance roles [y/n]: ")],
                           validator=YesNoValidator(), style=prompt_style).strip() == 'y'
-    logger.debug("use_role: {} {}".format(use_role, type(use_role)))
+    logger.debug(f"use_role: {use_role} {type(use_role)}")
     if use_role:
         if 'ROLE' in asg_cfg:
             role = asg_cfg['ROLE']
         else:
             role = prompt_roles(cur_roles)
-        logger.debug("role: {}".format(role))
+        logger.debug(f"role: {role}")
 
     # prompt for security groups
     if 'SECURITY_GROUPS' in asg_cfg and 'VPC' in asg_cfg:
@@ -207,12 +199,12 @@ def create(args, conf):
         vpc_id = asg_cfg.get('VPC', None)
     else:
         sgs, vpc_id = prompt_secgroup(cur_sgs)
-    logger.debug("security groups: {}".format(sgs))
-    logger.debug("VPC ID: {}".format(vpc_id))
+    logger.debug(f"security groups: {sgs}")
+    logger.debug(f"VPC ID: {vpc_id}")
 
     # get current AZs
     cur_azs = {i['ZoneName']: i for i in get_azs(ec2)}
-    logger.debug("cur_azs: {}".format(pformat(cur_azs)))
+    logger.debug(f"cur_azs: {pformat(cur_azs)}")
 
     # get subnet IDs and corresponding AZs for VPC
     subnets = []
@@ -224,8 +216,8 @@ def create(args, conf):
             subnets.append(sn_id)
             azs.add(sn_az)
     azs = list(azs)
-    logger.debug("subnets: {}".format(pformat(subnets)))
-    logger.debug("azs: {}".format(pformat(azs)))
+    logger.debug(f"subnets: {pformat(subnets)}")
+    logger.debug(f"azs: {pformat(azs)}")
 
 
     # check asgs that need to be configured
@@ -258,11 +250,11 @@ def create(args, conf):
 
         asg = "{}-{}".format(conf.get('VENUE'), queue)
         if asg in cur_asgs:
-            print(("ASG {} already exists. Skipping.".format(asg)))
+            print(f"ASG {asg} already exists. Skipping.")
             continue
 
         print_component_header(
-            "Configuring autoscaling group:\n{}".format(asg))
+            f"Configuring autoscaling group:\n{asg}")
 
         # get user data
         user_data = "BUNDLE_URL=s3://{}/{}-{}.tbz2".format(conf.get('CODE_BUCKET'),
@@ -287,12 +279,12 @@ def create(args, conf):
         if use_role:
             lt_args['LaunchTemplateData']['IamInstanceProfile'] = { 'Name': role }
 
-        lt = "{}-launch-template".format(asg)
+        lt = f"{asg}-launch-template"
         lt_args['LaunchTemplateName'] = lt
         lt_info = create_lt(ec2, **lt_args)
         logger.debug("Launch template {}: {}".format(
             lt, pformat(lt_info)))
-        print(("Created launch template {}.".format(lt)))
+        print(f"Created launch template {lt}.")
 
         # get autoscaling group config
         asg_args = {
@@ -326,7 +318,7 @@ def create(args, conf):
             'Tags': [
                 {
                     'Key': 'Name',
-                    'Value': '{}-worker'.format(asg),
+                    'Value': f'{asg}-worker',
                     'PropagateAtLaunch': True,
                 },
                 {
@@ -346,17 +338,17 @@ def create(args, conf):
                 },
             ],
         }
-        logger.debug("asg_args: {}".format(pformat(asg_args)))
+        logger.debug(f"asg_args: {pformat(asg_args)}")
         asg_info = create_asg(c, **asg_args)
-        logger.debug("Autoscaling group {}: {}".format(asg, pformat(asg_info)))
-        print("Created autoscaling group {}".format(asg))
+        logger.debug(f"Autoscaling group {asg}: {pformat(asg_info)}")
+        print(f"Created autoscaling group {asg}")
 
         # add target tracking scaling policy
-        policy_name = "{}-target-tracking".format(asg)
+        policy_name = f"{asg}-target-tracking"
         if total_jobs_metric:
-            metric_name = "JobsPerInstance-{}".format(asg)
+            metric_name = f"JobsPerInstance-{asg}"
         else:
-            metric_name = "JobsWaitingPerInstance-{}".format(asg)
+            metric_name = f"JobsWaitingPerInstance-{asg}"
         ttsp_args = {
             'AutoScalingGroupName': asg,
             'PolicyName': policy_name,
@@ -381,8 +373,8 @@ def create(args, conf):
                 'DisableScaleIn': True
             },
         }
-        logger.debug("ttsp_args: {}".format(pformat(ttsp_args)))
+        logger.debug(f"ttsp_args: {pformat(ttsp_args)}")
         ttsp_info = c.put_scaling_policy(**ttsp_args)
         logger.debug("Target tracking scaling policy {}: {}".format(
             policy_name, pformat(ttsp_info)))
-        print(("Added target tracking scaling policy {} to {}".format(policy_name, asg)))
+        print(f"Added target tracking scaling policy {policy_name} to {asg}")

--- a/sdscli/cloud/aws/storage.py
+++ b/sdscli/cloud/aws/storage.py
@@ -1,11 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-
-
-from builtins import int
-from builtins import open
 from future import standard_library
 standard_library.install_aliases()
 import os
@@ -49,7 +41,7 @@ def ls(args, conf):
     """List all buckets."""
 
     for bucket in get_buckets():
-        print((bucket['Name']))
+        print(bucket['Name'])
 
 
 def prompt_role(roles):
@@ -58,7 +50,7 @@ def prompt_role(roles):
     names = list(roles.keys())
     pt = [(Token, "Current roles are:\n\n")]
     for i, x in enumerate(names):
-        pt.append((Token.Param, "{}".format(i)))
+        pt.append((Token.Param, f"{i}"))
         pt.append((Token, ". {} - {} ({})\n".format(x,
                                                     roles[x]['Arn'], roles[x]['CreateDate'])))
     pt.append((Token, "\nSelect role to use for lambda execution: "))
@@ -68,7 +60,7 @@ def prompt_role(roles):
         try:
             return names[sel]
         except IndexError:
-            print(("Invalid selection: {}".format(sel)))
+            print(f"Invalid selection: {sel}")
 
 
 @cloud_config_check
@@ -115,17 +107,17 @@ def create_staging_area(args, conf):
     bucket_name = conf.get(
         'DATASET_BUCKET') if args.bucket is None else args.bucket
     bucket = get_bucket(bucket_name, c=s3_res)
-    logger.debug("bucket: {}".format(bucket))
+    logger.debug(f"bucket: {bucket}")
 
     # create SNS topic
-    logger.debug("prefix: {}".format(args.prefix))
-    logger.debug("suffix: {}".format(args.suffix))
+    logger.debug(f"prefix: {args.prefix}")
+    logger.debug(f"suffix: {args.suffix}")
     shasum = hashlib.sha224(
-        "{}-{}-{}".format(bucket_name, args.prefix, args.suffix).encode()).hexdigest()
+        f"{bucket_name}-{args.prefix}-{args.suffix}".encode()).hexdigest()
     topic_name = "{}-dataset-{}".format(conf.get('VENUE'), shasum[:4])
-    logger.debug("topic_name: {}".format(topic_name))
+    logger.debug(f"topic_name: {topic_name}")
     topic_arn = create_topic(Name=topic_name, c=sns_client)['TopicArn']
-    logger.debug("topic_arn: {}".format(topic_arn))
+    logger.debug(f"topic_arn: {topic_arn}")
 
     # add policy to allow S3 to publish to topic
     pol = {
@@ -150,7 +142,7 @@ def create_staging_area(args, conf):
                 "Resource": topic_arn,
                 "Condition": {
                     "StringEquals": {
-                        "aws:SourceArn": "arn:aws:s3:::{}".format(bucket_name)
+                        "aws:SourceArn": f"arn:aws:s3:::{bucket_name}"
                     }
                 }
             }
@@ -162,8 +154,8 @@ def create_staging_area(args, conf):
                                     AttributeValue=topic_name)
 
     # create notification event on bucket staging area
-    notification_name = "data-staged-{}".format(topic_name)
-    logger.debug("notification_name: {}".format(notification_name))
+    notification_name = f"data-staged-{topic_name}"
+    logger.debug(f"notification_name: {notification_name}")
     bn_args = {
         'NotificationConfiguration': {
             'TopicConfigurations': [
@@ -213,19 +205,19 @@ def create_staging_area(args, conf):
 
     # prompt for security groups
     cur_sgs = {i['GroupId']: i for i in get_sgs()}
-    logger.debug("cur_sgs: {}".format(pformat(cur_sgs)))
+    logger.debug(f"cur_sgs: {pformat(cur_sgs)}")
     desc = "\nSelect security groups lambda will use (space between each selected): "
     if 'LAMBDA_SECURITY_GROUPS' in sa_cfg and 'LAMBDA_VPC' in sa_cfg:
         sgs = sa_cfg.get('LAMBDA_SECURITY_GROUPS', [])
         vpc_id = sa_cfg.get('LAMBDA_VPC', None)
     else:
         sgs, vpc_id = prompt_secgroup(cur_sgs, desc)
-    logger.debug("security groups: {}".format(sgs))
-    logger.debug("VPC ID: {}".format(vpc_id))
+    logger.debug(f"security groups: {sgs}")
+    logger.debug(f"VPC ID: {vpc_id}")
 
     # get current AZs
     cur_azs = {i['ZoneName']: i for i in get_azs()}
-    logger.debug("cur_azs: {}".format(pformat(cur_azs)))
+    logger.debug(f"cur_azs: {pformat(cur_azs)}")
 
     # get subnet IDs and corresponding AZs for VPC
     subnets = []
@@ -237,19 +229,19 @@ def create_staging_area(args, conf):
             subnets.append(sn_id)
             azs.add(sn_az)
     azs = list(azs)
-    logger.debug("subnets: {}".format(pformat(subnets)))
-    logger.debug("azs: {}".format(pformat(azs)))
+    logger.debug(f"subnets: {pformat(subnets)}")
+    logger.debug(f"azs: {pformat(azs)}")
 
     # prompt for role
     roles = get_roles()
-    logger.debug("Found {} roles.".format(len(roles)))
+    logger.debug(f"Found {len(roles)} roles.")
     cur_roles = OrderedDict([(i['Arn'], i) for i in sorted(roles,
                                                            key=itemgetter('CreateDate'))])
     if 'LAMBDA_ROLE' in sa_cfg:
         role = sa_cfg['LAMBDA_ROLE']
     else:
         role = prompt_role(cur_roles)
-    logger.debug("Selected role: {}".format(role))
+    logger.debug(f"Selected role: {role}")
 
 
     # prompt for job type, release, and queue
@@ -259,21 +251,21 @@ def create_staging_area(args, conf):
         job_type = prompt(get_prompt_tokens=lambda x:
                           [(Token, "Enter job type to submit on data staged event: ")],
                           style=prompt_style).strip()
-    logger.debug("job type: {}".format(job_type))
+    logger.debug(f"job type: {job_type}")
     if 'JOB_RELEASE' in sa_cfg:
         job_release = sa_cfg['JOB_RELEASE']
     else:
         job_release = prompt(get_prompt_tokens=lambda x:
-                             [(Token, "Enter release version for {}: ".format(job_type))],
+                             [(Token, f"Enter release version for {job_type}: ")],
                              style=prompt_style).strip()
-    logger.debug("job release: {}".format(job_release))
+    logger.debug(f"job release: {job_release}")
     if 'JOB_QUEUE' in sa_cfg:
         job_queue = sa_cfg['JOB_QUEUE']
     else:
         job_queue = prompt(get_prompt_tokens=lambda x:
-                           [(Token, "Enter queue name to submit {}-{} jobs to: ".format(job_type, job_release))],
+                           [(Token, f"Enter queue name to submit {job_type}-{job_release} jobs to: ")],
                            style=prompt_style).strip()
-    logger.debug("job queue: {}".format(job_queue))
+    logger.debug(f"job queue: {job_queue}")
 
     job_types = {}
 
@@ -281,7 +273,7 @@ def create_staging_area(args, conf):
     if 'JOB_TYPES' in sa_cfg:
         job_types = sa_cfg['JOB_TYPES']
 
-    logger.debug("job types: {}".format(job_types))
+    logger.debug(f"job types: {job_types}")
 
 
     # create lambda
@@ -320,7 +312,7 @@ def create_staging_area(args, conf):
         cf_args["Environment"]["Variables"]["SIGNAL_FILE_SUFFIX"] = \
             args.suffix
     lambda_resp = lambda_client.create_function(**cf_args)
-    logger.debug("lambda_resp: {}".format(lambda_resp))
+    logger.debug(f"lambda_resp: {lambda_resp}")
 
     # add permission for sns to invoke lambda function
     lambda_client.add_permission(Action="lambda:InvokeFunction", FunctionName=function_name,
@@ -330,4 +322,4 @@ def create_staging_area(args, conf):
     # subscribe lambda endpoint to sns
     sns_resp = sns_client.subscribe(TopicArn=topic_arn, Protocol="lambda",
                                     Endpoint=lambda_resp['FunctionArn'])
-    logger.debug("sns_resp: {}".format(sns_resp))
+    logger.debug(f"sns_resp: {sns_resp}")

--- a/sdscli/cloud/aws/utils.py
+++ b/sdscli/cloud/aws/utils.py
@@ -1,10 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-
-from builtins import str
 from future import standard_library
 standard_library.install_aliases()
 import os
@@ -155,7 +148,7 @@ def configure_bucket_website(bucket_name, c=None, **kargs):
         bw.put(**kargs)
     except ClientError as e:
         logger.error(
-            "Failed to put bucket website config with:\n{}".format(str(e)))
+            f"Failed to put bucket website config with:\n{str(e)}")
         logger.error("Check that you have privileges.")
         return 1
     bw.load()
@@ -172,7 +165,7 @@ def configure_bucket_notification(bucket_name, c=None, **kargs):
         bn.put(**kargs)
     except ClientError as e:
         logger.error(
-            "Failed to put bucket notification config with:\n{}".format(str(e)))
+            f"Failed to put bucket notification config with:\n{str(e)}")
         logger.error("Check that you have privileges.")
         return 1
     bn.load()

--- a/sdscli/cloud/azure/utils.py
+++ b/sdscli/cloud/azure/utils.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-
 from future import standard_library
 standard_library.install_aliases()
 from sdscli.log_utils import logger

--- a/sdscli/cloud/gcp/utils.py
+++ b/sdscli/cloud/gcp/utils.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-
 from future import standard_library
 standard_library.install_aliases()
 from sdscli.log_utils import logger

--- a/sdscli/command_line.py
+++ b/sdscli/command_line.py
@@ -1,10 +1,6 @@
 """
 SDSKit command line interface.
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 
 from sdscli.log_utils import logger
@@ -26,16 +22,16 @@ standard_library.install_aliases()
 def get_adapter_func(sds_type, mod_name, func_name):
     """Import adapter function."""
 
-    adapter_mod = 'sdscli.adapters.%s.%s' % (sds_type, mod_name)
+    adapter_mod = f'sdscli.adapters.{sds_type}.{mod_name}'
     try:
         return get_func(adapter_mod, func_name)
     except ImportError:
-        logger.error('Failed to import adapter module "%s" for SDS type "%s".' % (
+        logger.error('Failed to import adapter module "{}" for SDS type "{}".'.format(
             mod_name, sds_type))
         logger.error('Not implemented yet. Mahalo for trying. ;)')
         sys.exit(1)
     except AttributeError:
-        logger.error('Failed to get function "%s" from adapter module "%s".' % (
+        logger.error('Failed to get function "{}" from adapter module "{}".'.format(
             func_name, adapter_mod))
         logger.error('Not implemented yet. Mahalo for trying. ;)')
         sys.exit(1)

--- a/sdscli/conf_utils.py
+++ b/sdscli/conf_utils.py
@@ -1,11 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-
-from builtins import super
-from builtins import open
 from future import standard_library
 standard_library.install_aliases()
 import os
@@ -33,13 +25,13 @@ class YamlConfError(Exception):
     pass
 
 
-class YamlConf(object):
+class YamlConf:
     """YAML configuration class."""
 
     def __init__(self, file):
         """Construct YamlConf instance."""
 
-        logger.debug("file: {}".format(file))
+        logger.debug(f"file: {file}")
         self._file = file
         with open(self._file) as f:
             self._cfg = yaml.load(f, Loader=yaml.FullLoader)
@@ -56,7 +48,7 @@ class YamlConf(object):
         try:
             return self._cfg[key]
         except KeyError as e:
-            raise YamlConfError("Configuration '{}' doesn't exist in {}.".format(key, self._file))
+            raise YamlConfError(f"Configuration '{key}' doesn't exist in {self._file}.")
 
 
 class SettingsConf(YamlConf):
@@ -67,4 +59,4 @@ class SettingsConf(YamlConf):
 
         if file is None:
             file = get_user_config_path()
-        super(SettingsConf, self).__init__(file)
+        super().__init__(file)

--- a/sdscli/func_utils.py
+++ b/sdscli/func_utils.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-
 from sdscli.log_utils import logger
 from importlib import import_module
 import logging

--- a/sdscli/log_utils.py
+++ b/sdscli/log_utils.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-
 from future import standard_library
 standard_library.install_aliases()
 import logging

--- a/sdscli/os_utils.py
+++ b/sdscli/os_utils.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-
 from future import standard_library
 standard_library.install_aliases()
 import os

--- a/sdscli/prompt_utils.py
+++ b/sdscli/prompt_utils.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-
-
 from future import standard_library
 standard_library.install_aliases()
 import os
@@ -92,41 +86,41 @@ class PriceValidator(Validator):
 def set_bar_desc(bar, message):
     """Set bar description."""
 
-    bar.set_description("{0: >20.20}".format(message))
+    bar.set_description(f"{message: >20.20}")
 
 
 def highlight(s, color="green", bold=True):
     """Return colored string."""
 
     color_code = COLOR_CODE[color].format("1" if bold else "0")
-    return "\033[{};40m{}\033[0m".format(color_code, s)
+    return f"\033[{color_code};40m{s}\033[0m"
 
 
 def blink(s):
     """Return blinking string."""
 
-    return "\033[5;40m{}\033[25m".format(s)
+    return f"\033[5;40m{s}\033[25m"
 
 
 def print_component_header(comp):
     """Print component header."""
 
-    print((highlight("#" * 40, 'cyan')))
-    print((highlight(comp, 'cyan', True)))
-    print((highlight("#" * 40, 'cyan')))
+    print(highlight("#" * 40, 'cyan'))
+    print(highlight(comp, 'cyan', True))
+    print(highlight("#" * 40, 'cyan'))
 
 
 def print_tps_header(comp):
     """Print tps header."""
 
-    print((highlight("-" * 40, 'cyan')))
-    print((highlight('third-party services', 'cyan', True)))
-    print((highlight("-" * 40, 'cyan')))
+    print(highlight("-" * 40, 'cyan'))
+    print(highlight('third-party services', 'cyan', True))
+    print(highlight("-" * 40, 'cyan'))
 
 
 def print_supervisor_header(comp):
     """Print supervisor header."""
 
-    print((highlight("-" * 40, 'cyan')))
-    print((highlight('supervised services', 'cyan', True)))
-    print((highlight("-" * 40, 'cyan')))
+    print(highlight("-" * 40, 'cyan'))
+    print(highlight('supervised services', 'cyan', True))
+    print(highlight("-" * 40, 'cyan'))

--- a/sdscli/query_utils.py
+++ b/sdscli/query_utils.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 
@@ -72,9 +68,9 @@ def run_query(url, idx, query):
     """Query ES index."""
     es = Elasticsearch([url])
 
-    logger.info("url: {}".format(url))
-    logger.info("idx: {}".format(idx))
-    logger.info("query: {}".format(json.dumps(query, indent=2)))
+    logger.info(f"url: {url}")
+    logger.info(f"idx: {idx}")
+    logger.info(f"query: {json.dumps(query, indent=2)}")
 
     hits = []
     page = es.search(index=idx, scroll='2m', size=100, body=query)
@@ -108,8 +104,8 @@ def query_dataset(url, idx, id, version=None, sort_order="desc"):
     # get index name and url
     query_url = "{}/{}/_search?search_type=scan&scroll=60&size=100".format(
         url, idx)
-    logger.info("url: {}".format(url))
-    logger.info("idx: {}".format(idx))
+    logger.info(f"url: {url}")
+    logger.info(f"idx: {idx}")
 
     # query
     query = {
@@ -144,7 +140,7 @@ def query_dataset(url, idx, id, version=None, sort_order="desc"):
             "term": {"version.raw": version}
         })
 
-    logger.info("query: {}".format(json.dumps(query, indent=2)))
+    logger.info(f"query: {json.dumps(query, indent=2)}")
     r = requests.post(query_url, data=json.dumps(query))
     r.raise_for_status()
     scan_result = r.json()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from setuptools import setup, find_packages
 import sdscli
 
@@ -19,7 +16,6 @@ setup(
         "prompt-toolkit>=1.0,<2.0",
         "tqdm>=4.32.1",
         "backoff>=1.8.0",
-        "future>=0.17.1",
         "requests>=2.22.0",
         "kombu>=4.5.0",
         "redis>=3.2.1",


### PR DESCRIPTION
- This PR updates the code for Python 3.12 compatibility
- Updates were made by running the `pyupgrade` tool
- Converted all `datetime.utcnow()` to `datetime.now(timezone.utc)`. In addition, where applicable, the calls have been updated to use the new `datetime_iso_naive` function in the hysds repo python 3.12 updates to maintain backwards compatibility.