### PR TITLE
HC-567: Multi-Architecture Container Support and Jenkins Pipeline Integration

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 __url__ = "https://github.com/hysds/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __url__ = "https://github.com/hysds/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/ci.py
+++ b/sdscli/adapters/hysds/ci.py
@@ -63,8 +63,9 @@ def add_job(args):
     if args.branch is None:
         execute(fab.add_ci_job_release, repo_url, args.storage, roles=['ci'])
     else:
+        pipeline = getattr(args, 'pipeline', False)
         execute(fab.add_ci_job, repo_url, args.storage,
-                args.branch, roles=['ci'])
+                args.branch, pipeline=pipeline, roles=['ci'])
 
     # reload
     execute(fab.reload_configuration, roles=['ci'])

--- a/sdscli/adapters/hysds/fabfile.py
+++ b/sdscli/adapters/hysds/fabfile.py
@@ -798,7 +798,7 @@ def python_setup_develop(node_type, dest):
 ##########################
 
 
-def get_ci_job_info(repo, branch=None):
+def get_ci_job_info(repo, branch=None, pipeline=False):
     ctx = get_context()
     match = repo_re.search(repo)
     if not match:
@@ -806,17 +806,17 @@ def get_ci_job_info(repo, branch=None):
     owner, name = match.groups()
     if branch is None:
         job_name = "{}_container-builder_{}_{}".format(ctx['VENUE'], owner, name)
-        config_tmpl = 'config.xml'
+        config_tmpl = 'config-pipeline.xml' if pipeline else 'config.xml'
     else:
         job_name = "{}_container-builder_{}_{}_{}".format(
             ctx['VENUE'], owner, name, branch)
-        config_tmpl = 'config-branch.xml'
+        config_tmpl = 'config-pipeline.xml' if pipeline else 'config-branch.xml'
     return job_name, config_tmpl
 
 
-def add_ci_job(repo, proto, branch=None, release=False):
+def add_ci_job(repo, proto, branch=None, release=False, pipeline=False):
     with settings(sudo_user=context["JENKINS_USER"]):
-        job_name, config_tmpl = get_ci_job_info(repo, branch)
+        job_name, config_tmpl = get_ci_job_info(repo, branch, pipeline=pipeline)
         ctx = get_context()
         ctx['PROJECT_URL'] = repo
         ctx['BRANCH'] = branch
@@ -828,6 +828,8 @@ def add_ci_job(repo, proto, branch=None, release=False):
             ctx['BRANCH_SPEC'] = "origin/tags/release-*"
         else:
             ctx['BRANCH_SPEC'] = "**"
+        if pipeline:
+            ctx['JENKINSFILE_PATH'] = 'Jenkinsfile'
         if proto in ('s3', 's3s'):
             ctx['STORAGE_URL'] = "{}://{}/{}/".format(
                 proto, ctx['S3_ENDPOINT'], ctx['CODE_BUCKET'])

--- a/sdscli/adapters/hysds/files/Jenkinsfile.example
+++ b/sdscli/adapters/hysds/files/Jenkinsfile.example
@@ -1,0 +1,393 @@
+#!/usr/bin/env groovy
+// Example Jenkinsfile for HySDS Multi-Architecture Container Builds
+// Copy this file to your project repository as "Jenkinsfile" and customize as needed
+
+pipeline {
+    agent none
+
+    environment {
+        // Standard HySDS environment variables (provided by Jenkins parameters)
+        GIT_OAUTH_TOKEN = "${params.GIT_OAUTH_TOKEN}"
+        PUBLIC_GIT_OAUTH_TOKEN = "${params.PUBLIC_GIT_OAUTH_TOKEN}"
+        CONTAINER_BUILDER_BRANCH = "${params.CONTAINER_BUILDER_BRANCH}"
+        CONTAINER_BUILDER_REPO = "${params.CONTAINER_BUILDER_REPO}"
+        DOCKER_REGISTRY_TAR_FILE = "${params.DOCKER_REGISTRY_TAR_FILE}"
+        MOZART_REST_URL = "${params.MOZART_REST_URL}"
+        GRQ_REST_URL = "${params.GRQ_REST_URL}"
+        CONTAINER_REGISTRY = "${params.CONTAINER_REGISTRY}"
+        CONTAINER_REGISTRY_BUCKET = "${params.CONTAINER_REGISTRY_BUCKET}"
+        STORAGE_URL = "${params.STORAGE_URL}"
+        OPS_HOME = "${params.OPS_HOME}"
+        SKIP_PUBLISH = "${env.SKIP_PUBLISH ?: 'noskip'}"
+        
+        // TODO: Add your project-specific environment variables here
+        // Example: CUSTOM_BRANCH = "${params.CUSTOM_BRANCH}"
+    }
+
+    stages {
+        stage('Setup') {
+            agent any
+            steps {
+                deleteDir()
+                checkout([
+                    $class: 'GitSCM',
+                    branches: scm.branches,
+                    extensions: [
+                        [$class: 'CloneOption', noTags: false, shallow: false, depth: 0, reference: ''],
+                        [$class: 'CleanBeforeCheckout']
+                    ],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                ])
+                script {
+                    env.TAG = env.GIT_BRANCH.tokenize('/').last()
+                    def repoPath = env.GIT_URL.replaceAll(/^.*:\/\/[^\/]+\//, '').replaceAll(/\.git$/, '')
+                    def repo = repoPath.replaceAll('/', '_')
+                    env.REPO = repo
+                    env.IMAGE_NAME = "container-${repo.toLowerCase()}"
+
+                    echo "[CI] Building ${env.IMAGE_NAME}:${env.TAG}"
+                    echo "[CI] Build mode: ${params.BUILD_MODE}"
+                }
+            }
+        }
+
+        stage('Build Multi-Architecture') {
+            when {
+                expression { params.BUILD_MODE == 'multi-platform' }
+            }
+            parallel {
+                stage('Build amd64') {
+                    agent any
+                    steps {
+                        checkout([
+                            $class: 'GitSCM',
+                            branches: scm.branches,
+                            extensions: [
+                                [$class: 'CloneOption', noTags: false, shallow: false, depth: 0, reference: ''],
+                                [$class: 'CleanBeforeCheckout']
+                            ],
+                            userRemoteConfigs: scm.userRemoteConfigs
+                        ])
+                        script {
+                            echo "[CI] Building amd64 architecture on native x86_64 node"
+                            
+                            // TODO: Customize your build command and build args
+                            sh """
+                                source ${OPS_HOME}/verdi/bin/activate
+
+                                if [ ! -z "${CONTAINER_REGISTRY}" -a ! -z "${CONTAINER_REGISTRY_BUCKET}" ]; then
+                                    ${OPS_HOME}/verdi/ops/container-builder/build-container.bash \
+                                        ${REPO} ${TAG}-amd64 ${STORAGE_URL} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ${CONTAINER_REGISTRY} \
+                                        --build-arg GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN} \
+                                        --build-arg BRANCH=${TAG} \
+                                        --platform linux/amd64 \
+                                        --skip-metadata
+                                else
+                                    ${OPS_HOME}/verdi/ops/container-builder/build-container.bash \
+                                        ${REPO} ${TAG}-amd64 ${STORAGE_URL} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} "" \
+                                        --build-arg GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN} \
+                                        --build-arg BRANCH=${TAG} \
+                                        --platform linux/amd64 \
+                                        --skip-metadata
+                                fi
+                            """
+                        }
+                    }
+                }
+
+                stage('Build arm64') {
+                    agent { label 'arm-build' }
+                    steps {
+                        checkout([
+                            $class: 'GitSCM',
+                            branches: scm.branches,
+                            extensions: [
+                                [$class: 'CloneOption', noTags: false, shallow: false, depth: 0, reference: ''],
+                                [$class: 'CleanBeforeCheckout']
+                            ],
+                            userRemoteConfigs: scm.userRemoteConfigs
+                        ])
+                        script {
+                            echo "[CI] Building arm64 architecture on native ARM64 node"
+
+                            def ARM_OPS_HOME = '/home/ops'
+                            def arm64TarFile = env.DOCKER_REGISTRY_TAR_FILE.replace('.tar.gz', '-arm64.tar.gz')
+
+                            // TODO: Customize your build command and build args
+                            sh """
+                                set -e
+
+                                # Clone container builder repository
+                                echo "[CI] Cloning container builder: ${CONTAINER_BUILDER_REPO} (branch: ${CONTAINER_BUILDER_BRANCH})"
+                                if [ -d ${ARM_OPS_HOME}/verdi/ops/container-builder ]; then
+                                    rm -rf ${ARM_OPS_HOME}/verdi/ops/container-builder
+                                fi
+                                git clone -b ${CONTAINER_BUILDER_BRANCH} https://${PUBLIC_GIT_OAUTH_TOKEN}@${CONTAINER_BUILDER_REPO} ${ARM_OPS_HOME}/verdi/ops/container-builder
+
+                                # Download and load docker registry
+                                echo "[CI] Setting up Docker registry"
+                                aws s3 cp ${STORAGE_URL}/${arm64TarFile} .
+                                docker load -i ${arm64TarFile}
+
+                                # Start docker registry
+                                echo "[CI] Starting Docker registry"
+                                docker rm -f registry || true
+                                docker run -p 5050:5000 -e REGISTRY_STORAGE=s3 -e REGISTRY_STORAGE_S3_BUCKET=${CONTAINER_REGISTRY_BUCKET} -e REGISTRY_STORAGE_S3_REGION=us-west-2 --name=registry -d registry:2
+
+                                source ${ARM_OPS_HOME}/verdi/bin/activate
+
+                                if [ ! -z "${CONTAINER_REGISTRY}" -a ! -z "${CONTAINER_REGISTRY_BUCKET}" ]; then
+                                    ${ARM_OPS_HOME}/verdi/ops/container-builder/build-container.bash \
+                                        ${REPO} ${TAG}-arm64 ${STORAGE_URL} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ${CONTAINER_REGISTRY} \
+                                        --build-arg GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN} \
+                                        --build-arg BRANCH=${TAG} \
+                                        --platform linux/arm64 \
+                                        --skip-metadata
+                                else
+                                    ${ARM_OPS_HOME}/verdi/ops/container-builder/build-container.bash \
+                                        ${REPO} ${TAG}-arm64 ${STORAGE_URL} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} "" \
+                                        --build-arg GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN} \
+                                        --build-arg BRANCH=${TAG} \
+                                        --platform linux/arm64 \
+                                        --skip-metadata
+                                fi
+                            """
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Build Single Architecture') {
+            when {
+                expression { params.BUILD_MODE == 'amd64-only' || params.BUILD_MODE == 'arm64-only' }
+            }
+            agent {
+                label "${params.BUILD_MODE == 'arm64-only' ? 'arm-build' : ''}"
+            }
+            steps {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: scm.branches,
+                    extensions: [
+                        [$class: 'CloneOption', noTags: false, shallow: false, depth: 0, reference: ''],
+                        [$class: 'CleanBeforeCheckout']
+                    ],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                ])
+                script {
+                    def platform = params.BUILD_MODE == 'arm64-only' ? 'linux/arm64' : 'linux/amd64'
+                    def isArm64 = params.BUILD_MODE == 'arm64-only'
+                    def opsHome = isArm64 ? '/home/ops' : env.OPS_HOME
+
+                    echo "[CI] Building single architecture: ${platform}"
+
+                    if (isArm64) {
+                        def arm64TarFile = env.DOCKER_REGISTRY_TAR_FILE.replace('.tar.gz', '-arm64.tar.gz')
+                        
+                        // TODO: Customize ARM64 build command
+                        sh """
+                            set -e
+
+                            # Clone container builder
+                            if [ -d ${opsHome}/verdi/ops/container-builder ]; then
+                                rm -rf ${opsHome}/verdi/ops/container-builder
+                            fi
+                            git clone -b ${CONTAINER_BUILDER_BRANCH} https://${PUBLIC_GIT_OAUTH_TOKEN}@${CONTAINER_BUILDER_REPO} ${opsHome}/verdi/ops/container-builder
+
+                            # Setup Docker registry
+                            aws s3 cp ${STORAGE_URL}/${arm64TarFile} .
+                            docker load -i ${arm64TarFile}
+                            docker rm -f registry || true
+                            docker run -p 5050:5000 -e REGISTRY_STORAGE=s3 -e REGISTRY_STORAGE_S3_BUCKET=${CONTAINER_REGISTRY_BUCKET} -e REGISTRY_STORAGE_S3_REGION=us-west-2 --name=registry -d registry:2
+
+                            source ${opsHome}/verdi/bin/activate
+
+                            if [ ! -z "${CONTAINER_REGISTRY}" -a ! -z "${CONTAINER_REGISTRY_BUCKET}" ]; then
+                                ${opsHome}/verdi/ops/container-builder/build-container.bash \
+                                    ${REPO} ${TAG} ${STORAGE_URL} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ${CONTAINER_REGISTRY} \
+                                    --build-arg GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN} \
+                                    --build-arg BRANCH=${TAG} \
+                                    --platform ${platform}
+                            else
+                                ${opsHome}/verdi/ops/container-builder/build-container.bash \
+                                    ${REPO} ${TAG} ${STORAGE_URL} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} "" \
+                                    --build-arg GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN} \
+                                    --build-arg BRANCH=${TAG} \
+                                    --platform ${platform}
+                            fi
+                        """
+                    } else {
+                        // TODO: Customize amd64 build command
+                        sh """
+                            source ${opsHome}/verdi/bin/activate
+
+                            if [ ! -z "${CONTAINER_REGISTRY}" -a ! -z "${CONTAINER_REGISTRY_BUCKET}" ]; then
+                                ${opsHome}/verdi/ops/container-builder/build-container.bash \
+                                    ${REPO} ${TAG} ${STORAGE_URL} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ${CONTAINER_REGISTRY} \
+                                    --build-arg GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN} \
+                                    --build-arg BRANCH=${TAG} \
+                                    --platform ${platform}
+                            else
+                                ${opsHome}/verdi/ops/container-builder/build-container.bash \
+                                    ${REPO} ${TAG} ${STORAGE_URL} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} "" \
+                                    --build-arg GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN} \
+                                    --build-arg BRANCH=${TAG} \
+                                    --platform ${platform}
+                            fi
+                        """
+                    }
+                }
+            }
+        }
+
+        stage('Create Multi-Platform Manifest') {
+            when {
+                expression { params.BUILD_MODE == 'multi-platform' && env.CONTAINER_REGISTRY != null && env.CONTAINER_REGISTRY != '' }
+            }
+            agent any
+            steps {
+                script {
+                    echo "[CI] Creating multi-platform manifest from architecture-specific images"
+                    sh """
+                        set -ex
+
+                        # Setup Docker registry
+                        aws s3 cp ${STORAGE_URL}/${DOCKER_REGISTRY_TAR_FILE} .
+                        docker load -i ${DOCKER_REGISTRY_TAR_FILE}
+                        docker rm -f registry || true
+                        docker run -p 5050:5000 \
+                            -e REGISTRY_STORAGE=s3 \
+                            -e REGISTRY_STORAGE_S3_BUCKET=${CONTAINER_REGISTRY_BUCKET} \
+                            -e REGISTRY_STORAGE_S3_REGION=us-west-2 \
+                            --name=registry -d registry:2
+
+                        sleep 10
+
+                        REGISTRY="${CONTAINER_REGISTRY}"
+                        IMAGE="${IMAGE_NAME}"
+                        TAG_LOWER="\${TAG,,}"
+
+                        # Create multi-platform manifest
+                        docker buildx imagetools create -t \${REGISTRY}/\${IMAGE}:\${TAG_LOWER} \
+                            \${REGISTRY}/\${IMAGE}:\${TAG_LOWER}-amd64 \
+                            \${REGISTRY}/\${IMAGE}:\${TAG_LOWER}-arm64
+
+                        # Verify manifest
+                        docker buildx imagetools inspect \${REGISTRY}/\${IMAGE}:\${TAG_LOWER}
+
+                        # Create tarballs for both architectures
+                        TARBALL_X86="\${IMAGE}-\${TAG_LOWER}.tar.gz"
+                        TARBALL_ARM64="\${IMAGE}-\${TAG_LOWER}-arm64.tar.gz"
+
+                        docker pull --platform linux/amd64 \${REGISTRY}/\${IMAGE}:\${TAG_LOWER}
+                        docker tag \${REGISTRY}/\${IMAGE}:\${TAG_LOWER} \${IMAGE}:\${TAG_LOWER}
+                        docker save \${IMAGE}:\${TAG_LOWER} | gzip > \${TARBALL_X86}
+
+                        docker pull --platform linux/arm64 \${REGISTRY}/\${IMAGE}:\${TAG_LOWER}
+                        docker tag \${REGISTRY}/\${IMAGE}:\${TAG_LOWER} \${IMAGE}:\${TAG_LOWER}
+                        docker save \${IMAGE}:\${TAG_LOWER} | gzip > \${TARBALL_ARM64}
+
+                        # Upload tarballs
+                        aws s3 cp \${TARBALL_X86} ${STORAGE_URL}/
+                        aws s3 cp \${TARBALL_ARM64} ${STORAGE_URL}/
+
+                        # Get digest
+                        docker pull \${REGISTRY}/\${IMAGE}:\${TAG_LOWER}
+                        DIGEST=\$(docker inspect --format='{{index .Id}}' \${REGISTRY}/\${IMAGE}:\${TAG_LOWER} | cut -d'@' -f 2)
+
+                        # Activate verdi and publish metadata
+                        source ${OPS_HOME}/verdi/bin/activate
+
+                        # Get container-builder path
+                        if [ -d ${OPS_HOME}/verdi/ops/container-builder ]; then
+                            CONTAINER_BUILDER_PATH="${OPS_HOME}/verdi/ops/container-builder"
+                        else
+                            git clone -b ${CONTAINER_BUILDER_BRANCH} https://${PUBLIC_GIT_OAUTH_TOKEN}@${CONTAINER_BUILDER_REPO} ${OPS_HOME}/verdi/ops/container-builder
+                            CONTAINER_BUILDER_PATH="${OPS_HOME}/verdi/ops/container-builder"
+                        fi
+
+                        # Publish container metadata with multi-arch URLs
+                        \${CONTAINER_BUILDER_PATH}/container-met.py \${IMAGE}:\${TAG_LOWER} ${TAG} "\${TARBALL_X86}" ${STORAGE_URL} \${DIGEST} ${MOZART_REST_URL} "\${TARBALL_ARM64}"
+
+                        # Publish job-spec metadata
+                        cd ${WORKSPACE}
+                        for specification in docker/job-spec.json*; do
+                            if [ -f "\${specification}" ]; then
+                                specification=\${specification#docker/}
+                                NAME=${REPO}
+                                if [[ "\${specification}" != "job-spec.json" ]]; then
+                                    NAME=\${specification#job-spec.json.}
+                                fi
+                                \${CONTAINER_BUILDER_PATH}/job-met.py docker/\${specification} \${IMAGE}:\${TAG_LOWER} ${TAG} ${MOZART_REST_URL} ${STORAGE_URL}
+                            fi
+                        done
+
+                        # Publish hysds-io metadata
+                        for wiring in docker/hysds-io.json*; do
+                            if [ -f "\${wiring}" ]; then
+                                wiring=\${wiring#docker/}
+                                NAME=${REPO}
+                                if [[ "\${wiring}" != "hysds-io.json" ]]; then
+                                    NAME=\${wiring#hysds-io.json.}
+                                fi
+                                SPEC="job-\${NAME}:${TAG}"
+                                \${CONTAINER_BUILDER_PATH}/io-met.py docker/\${wiring} \${SPEC} ${TAG} ${MOZART_REST_URL} ${GRQ_REST_URL}
+                            fi
+                        done
+                    """
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                node {
+                    // Archive test artifacts if they exist
+                    archiveArtifacts artifacts: '**/pytest_unit*.xml, **/flake8*.log, **/prospector*.log', allowEmptyArchive: true
+                    junit testResults: '**/pytest_unit*.xml', allowEmptyResults: true, keepLongStdio: true
+
+                    // Publish HTML coverage reports if they exist
+                    publishHTML([
+                        allowMissing: true,
+                        alwaysLinkToLastBuild: false,
+                        keepAll: true,
+                        reportDir: 'coverage-amd64.html',
+                        reportFiles: 'index.html',
+                        reportName: 'Coverage Report (amd64)',
+                        reportTitles: ''
+                    ])
+
+                    publishHTML([
+                        allowMissing: true,
+                        alwaysLinkToLastBuild: false,
+                        keepAll: true,
+                        reportDir: 'coverage-arm64.html',
+                        reportFiles: 'index.html',
+                        reportName: 'Coverage Report (arm64)',
+                        reportTitles: ''
+                    ])
+
+                    // Publish warnings for flake8 and prospector
+                    recordIssues(
+                        enabledForFailure: true,
+                        tools: [
+                            flake8(pattern: '**/flake8*.log'),
+                            pyLint(pattern: '**/prospector*.log')
+                        ]
+                    )
+                }
+            }
+        }
+
+        success {
+            echo "[CI] Build completed successfully!"
+        }
+
+        failure {
+            echo "[CI] Build failed. Check logs for details."
+        }
+    }
+}

--- a/sdscli/adapters/hysds/files/README.md
+++ b/sdscli/adapters/hysds/files/README.md
@@ -1,0 +1,119 @@
+# HySDS Jenkins Pipeline Configuration Files
+
+This directory contains example configuration files for setting up Jenkins pipeline jobs with multi-architecture container build support.
+
+## Files
+
+### config-pipeline.xml
+Generic Jenkins job configuration template for pipeline jobs. This file is used by `sds ci add_job --pipeline` to create Jenkins pipeline jobs.
+
+**Template Variables:**
+- `{{ PROJECT_URL }}` - Git repository URL
+- `{{ BRANCH }}` - Git branch to build
+- `{{ JENKINSFILE_PATH }}` - Path to Jenkinsfile in repository (default: `Jenkinsfile`)
+
+**Usage:**
+This file is automatically used when you run:
+```bash
+sds ci add_job <repo-url> <storage-type> --branch <branch> --pipeline
+```
+
+### Jenkinsfile.example
+Example Jenkinsfile demonstrating multi-architecture container builds for HySDS projects.
+
+**Features:**
+- Multi-platform builds (amd64 + arm64)
+- Single-architecture builds (amd64-only or arm64-only)
+- Multi-platform manifest creation
+- Metadata publishing to Mozart and GRQ
+- Test artifact collection and reporting
+
+**How to Use:**
+
+1. **Copy to your project repository:**
+   ```bash
+   cp Jenkinsfile.example /path/to/your/project/Jenkinsfile
+   ```
+
+2. **Customize for your project:**
+   - Add project-specific environment variables in the `environment` section
+   - Customize build arguments in the build stages (search for `TODO` comments)
+   - Add or remove build arguments as needed for your Dockerfile
+   - Adjust artifact extraction if your project has different test outputs
+
+3. **Common customizations:**
+   
+   **Add custom build arguments:**
+   ```groovy
+   --build-arg GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN} \
+   --build-arg BRANCH=${TAG} \
+   --build-arg YOUR_CUSTOM_ARG=${YOUR_CUSTOM_VALUE} \
+   ```
+   
+   **Add custom environment variables:**
+   ```groovy
+   environment {
+       // ... existing vars ...
+       CUSTOM_BRANCH = "${params.CUSTOM_BRANCH}"
+       CUSTOM_CONFIG = "${params.CUSTOM_CONFIG}"
+   }
+   ```
+   
+   **Customize container-builder path:**
+   The example uses generic paths. Update if your setup uses different paths:
+   ```groovy
+   ${OPS_HOME}/verdi/ops/container-builder/build-container.bash
+   ```
+
+4. **Commit to your repository:**
+   ```bash
+   git add Jenkinsfile
+   git commit -m "Add Jenkins pipeline for multi-arch builds"
+   git push
+   ```
+
+5. **Register with Jenkins:**
+   ```bash
+   sds ci add_job <your-repo-url> <storage-type> --branch <branch> --pipeline
+   ```
+
+## Build Modes
+
+The example Jenkinsfile supports three build modes (controlled by Jenkins parameter):
+
+- **`multi-platform`**: Builds both amd64 and arm64 in parallel, then creates a multi-platform manifest
+- **`amd64-only`**: Builds only amd64 architecture
+- **`arm64-only`**: Builds only arm64 architecture on ARM build nodes
+
+## Jenkins Parameters
+
+The following parameters should be configured in your Jenkins job:
+
+**Required:**
+- `BUILD_MODE` - Choice: multi-platform, amd64-only, arm64-only
+- `GIT_OAUTH_TOKEN` - OAuth token for private repositories
+- `MOZART_REST_URL` - Mozart REST API endpoint
+- `GRQ_REST_URL` - GRQ REST API endpoint
+- `STORAGE_URL` - S3/storage URL for artifacts
+- `OPS_HOME` - HySDS ops home directory
+
+**For multi-platform builds:**
+- `CONTAINER_REGISTRY` - Container registry URL
+- `CONTAINER_REGISTRY_BUCKET` - S3 bucket for registry storage
+- `DOCKER_REGISTRY_TAR_FILE` - Docker registry tar file name
+- `CONTAINER_BUILDER_REPO` - Container builder repository
+- `CONTAINER_BUILDER_BRANCH` - Container builder branch
+- `PUBLIC_GIT_OAUTH_TOKEN` - OAuth token for public repositories
+
+## Notes
+
+- ARM64 builds require Jenkins nodes with the `arm-build` label
+- The example assumes container-builder is available in the verdi environment
+- Customize the artifact extraction and test reporting sections based on your project's test framework
+- The multi-platform manifest stage requires a container registry with S3 backend
+
+## Additional Resources
+
+- [HySDS Documentation](https://hysds.github.io/)
+- [Jenkins Pipeline Syntax](https://www.jenkins.io/doc/book/pipeline/syntax/)
+- [Docker Buildx Multi-platform](https://docs.docker.com/build/building/multi-platform/)

--- a/sdscli/adapters/hysds/files/config-branch.xml
+++ b/sdscli/adapters/hysds/files/config-branch.xml
@@ -4,6 +4,21 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>PLATFORM</name>
+          <description>Target platform architecture for container build</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>linux/amd64</string>
+              <string>linux/arm64</string>
+              <string>linux/amd64,linux/arm64</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
         <daysToKeep>14</daysToKeep>
@@ -73,10 +88,10 @@ set -ex
 if [ ! -z "$CONTAINER_REGISTRY" -a ! -z "$CONTAINER_REGISTRY_BUCKET" ]
 then
   {{ OPS_HOME }}/verdi/ops/container-builder/build-container.bash \
-  ${REPO} ${TAG} ${STORAGE} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ${CONTAINER_REGISTRY}
+  ${REPO} ${TAG} ${STORAGE} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ${CONTAINER_REGISTRY} --platform $PLATFORM
 else
   {{ OPS_HOME }}/verdi/ops/container-builder/build-container.bash \
-  ${REPO} ${TAG} ${STORAGE} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ""
+  ${REPO} ${TAG} ${STORAGE} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} "" --platform $PLATFORM
 fi
 
 if [ -f "./docker/extract_artifacts.sh" ]; then

--- a/sdscli/adapters/hysds/files/config-pipeline.xml
+++ b/sdscli/adapters/hysds/files/config-pipeline.xml
@@ -1,0 +1,138 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.40">
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>14</daysToKeep>
+        <numToKeep>14</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.18.2">
+      <projectUrl>{{ PROJECT_URL }}</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>BUILD_MODE</name>
+          <description>Build mode: multi-platform creates manifest from both architectures</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>multi-platform</string>
+              <string>amd64-only</string>
+              <string>arm64-only</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
+          <name>SKIP_TESTS</name>
+          <description>Skip test execution</description>
+          <defaultValue>false</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
+        <hudson.model.PasswordParameterDefinition>
+          <name>GIT_OAUTH_TOKEN</name>
+          <description>Git OAuth Token</description>
+          <defaultValue>{{ GIT_OAUTH_TOKEN }}</defaultValue>
+        </hudson.model.PasswordParameterDefinition>
+        <hudson.model.PasswordParameterDefinition>
+          <name>PUBLIC_GIT_OAUTH_TOKEN</name>
+          <description>Public Git OAuth Token</description>
+          <defaultValue>{{ PUBLIC_GIT_OAUTH_TOKEN }}</defaultValue>
+        </hudson.model.PasswordParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CONTAINER_BUILDER_BRANCH</name>
+          <description>Container builder branch to use</description>
+          <defaultValue>{{ CONTAINER_BUILDER_BRANCH }}</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CONTAINER_BUILDER_REPO</name>
+          <description>Container builder repository</description>
+          <defaultValue>{{ CONTAINER_BUILDER_REPO }}</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>DOCKER_REGISTRY_TAR_FILE</name>
+          <description>Docker registry tar file (base name, -arm64 suffix added automatically for ARM64 builds)</description>
+          <defaultValue>docker-registry-2.tar.gz</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>MOZART_REST_URL</name>
+          <description>Mozart REST API URL (hidden)</description>
+          <defaultValue>https://{{ MOZART_PVT_IP }}/mozart/api/v0.1</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>GRQ_REST_URL</name>
+          <description>GRQ REST API URL (hidden)</description>
+          <defaultValue>https://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CONTAINER_REGISTRY</name>
+          <description>Container registry URL (hidden)</description>
+          <defaultValue>{{ CONTAINER_REGISTRY }}</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CONTAINER_REGISTRY_BUCKET</name>
+          <description>Container registry bucket (hidden)</description>
+          <defaultValue>{{ CONTAINER_REGISTRY_BUCKET }}</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>STORAGE_URL</name>
+          <description>Storage URL (hidden)</description>
+          <defaultValue>s3://{{ CODE_BUCKET }}</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>OPS_HOME</name>
+          <description>Operations home directory (hidden)</description>
+          <defaultValue>{{ OPS_HOME }}</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+    <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+      <triggers>
+        <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.18.2">
+          <spec></spec>
+        </com.cloudbees.jenkins.GitHubPushTrigger>
+      </triggers>
+    </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.87">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@4.7.1">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <refspec>+refs/heads/*:refs/remotes/origin/*</refspec>
+          <url>{{ PROJECT_URL }}</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>**/{{ BRANCH }}</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <submoduleCfg class="list"/>
+      <extensions/>
+    </scm>
+    <scriptPath>conf/sds/files/Jenkinsfile</scriptPath>
+    <lightweight>true</lightweight>
+  </definition>
+  <triggers>
+    <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.18.2">
+      <spec></spec>
+    </com.cloudbees.jenkins.GitHubPushTrigger>
+  </triggers>
+  <disabled>false</disabled>
+</flow-definition>

--- a/sdscli/adapters/hysds/files/config.xml
+++ b/sdscli/adapters/hysds/files/config.xml
@@ -4,6 +4,21 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>PLATFORM</name>
+          <description>Target platform architecture for container build</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>linux/amd64</string>
+              <string>linux/arm64</string>
+              <string>linux/amd64,linux/arm64</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
         <daysToKeep>14</daysToKeep>
@@ -74,10 +89,10 @@ set -ex
 if [ ! -z "$CONTAINER_REGISTRY" -a ! -z "$CONTAINER_REGISTRY_BUCKET" ]
 then
   {{ OPS_HOME }}/verdi/ops/container-builder/build-container.bash \
-  ${REPO} ${TAG} ${STORAGE} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ${CONTAINER_REGISTRY}
+  ${REPO} ${TAG} ${STORAGE} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ${CONTAINER_REGISTRY} --platform $PLATFORM
 else
   {{ OPS_HOME }}/verdi/ops/container-builder/build-container.bash \
-  ${REPO} ${TAG} ${STORAGE} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} ""
+  ${REPO} ${TAG} ${STORAGE} ${MOZART_REST_URL} ${GRQ_REST_URL} ${SKIP_PUBLISH} "" --platform $PLATFORM
 fi
 
 if [ -f "./docker/extract_artifacts.sh" ]; then

--- a/sdscli/adapters/hysds/pkg.py
+++ b/sdscli/adapters/hysds/pkg.py
@@ -61,8 +61,27 @@ def export(args):
 
     validate_dir(export_dir)  # create export directory
 
-    # download container if url provided
-    if cont_info.get('url', None) != None:
+    # download container(s) - handle both multi-arch (urls) and legacy (url)
+    if cont_info.get('urls'):
+        try:
+            urls_dict = json.loads(cont_info['urls'])
+            # Download all unique architecture-specific containers
+            unique_urls = set(urls_dict.values())
+            downloaded_files = {}
+            for url in unique_urls:
+                logger.info(f"Downloading container: {url}")
+                get(url, export_dir)
+                downloaded_files[url] = os.path.basename(url)
+            
+            # Update urls dict with local filenames
+            updated_urls = {}
+            for arch, url in urls_dict.items():
+                updated_urls[arch] = downloaded_files[url]
+            cont_info['urls'] = json.dumps(updated_urls)
+        except (json.JSONDecodeError, AttributeError) as e:
+            logger.error(f"Failed to parse urls field: {e}")
+    elif cont_info.get('url', None) != None:
+        # Legacy single-arch container
         get(cont_info['url'], export_dir)
         cont_info['url'] = os.path.basename(cont_info['url'])
 
@@ -92,18 +111,48 @@ def export(args):
     hysds_ios = []  # pull hysds_ios for each job_spec and download any dependency images
     dep_images = {}
     for job_spec in job_specs:
-        # download dependency images
+        # download dependency images - handle both multi-arch (container_image_urls) and legacy (container_image_url)
         for d in job_spec.get('dependency_images', []):
-            if d['container_image_name'] in dep_images:
-                d['container_image_url'] = dep_images[d['container_image_name']]
+            dep_name = d['container_image_name']
+            if dep_name in dep_images:
+                # Already processed this dependency - reuse cached values
+                cached = dep_images[dep_name]
+                if 'container_image_urls' in cached:
+                    d['container_image_urls'] = cached['container_image_urls']
+                if 'container_image_url' in cached:
+                    d['container_image_url'] = cached['container_image_url']
             else:
-                # download container
-                if args.skip_include_dependency_images:
-                    logger.info(f"Skipping download of dependency image: {d['container_image_url']}.")
-                else:
-                    get(d['container_image_url'], export_dir)
-                d['container_image_url'] = os.path.basename(d['container_image_url'])
-                dep_images[d['container_image_name']] = d['container_image_url']
+                # Handle multi-arch dependency images
+                if d.get('container_image_urls'):
+                    try:
+                        urls_dict = json.loads(d['container_image_urls'])
+                        unique_urls = set(urls_dict.values())
+                        downloaded_files = {}
+                        for url in unique_urls:
+                            if args.skip_include_dependency_images:
+                                logger.info(f"Skipping download of dependency image: {url}")
+                                downloaded_files[url] = os.path.basename(url)
+                            else:
+                                logger.info(f"Downloading dependency image: {url}")
+                                get(url, export_dir)
+                                downloaded_files[url] = os.path.basename(url)
+                        
+                        # Update urls dict with local filenames
+                        updated_urls = {}
+                        for arch, url in urls_dict.items():
+                            updated_urls[arch] = downloaded_files[url]
+                        d['container_image_urls'] = json.dumps(updated_urls)
+                        dep_images[dep_name] = {'container_image_urls': d['container_image_urls']}
+                    except (json.JSONDecodeError, AttributeError) as e:
+                        logger.error(f"Failed to parse container_image_urls field for dependency: {e}")
+                # Handle legacy single-arch dependency images
+                elif d.get('container_image_url'):
+                    if args.skip_include_dependency_images:
+                        logger.info(f"Skipping download of dependency image: {d['container_image_url']}")
+                    else:
+                        get(d['container_image_url'], export_dir)
+                    d['container_image_url'] = os.path.basename(d['container_image_url'])
+                    dep_images[dep_name] = {'container_image_url': d['container_image_url']}
 
         # collect hysds_ios from mozart
         query = {
@@ -220,8 +269,29 @@ def import_pkg(args):
 
     cont_info = manifest['containers']
 
-    # upload container image to s3
-    if cont_info.get('url', None) != None:
+    # upload container image(s) to s3 - handle both multi-arch (urls) and legacy (url)
+    if cont_info.get('urls'):
+        try:
+            urls_dict = json.loads(cont_info['urls'])
+            # Upload all unique architecture-specific containers
+            unique_files = set(urls_dict.values())
+            uploaded_urls = {}
+            for filename in unique_files:
+                cont_image = os.path.join(export_dir, filename)
+                s3_url = "{}/{}".format(code_bucket_url, filename)
+                logger.info(f"Uploading container: {filename} to {s3_url}")
+                put(cont_image, s3_url)
+                uploaded_urls[filename] = s3_url
+            
+            # Update urls dict with S3 URLs
+            updated_urls = {}
+            for arch, filename in urls_dict.items():
+                updated_urls[arch] = uploaded_urls[filename]
+            cont_info['urls'] = json.dumps(updated_urls)
+        except (json.JSONDecodeError, AttributeError) as e:
+            logger.error(f"Failed to parse urls field: {e}")
+    elif cont_info.get('url', None) != None:
+        # Legacy single-arch container
         cont_image = os.path.join(export_dir, cont_info['url'])
         cont_info['url'] = "{}/{}".format(code_bucket_url, cont_info['url'])
         put(cont_image, cont_info['url'])
@@ -233,19 +303,50 @@ def import_pkg(args):
     # index job_specs in ES and upload any dependency containers
     dep_images = {}
     for job_spec in manifest['job_specs']:
-        # download dependency images
+        # upload dependency images - handle both multi-arch (container_image_urls) and legacy (container_image_url)
         for d in job_spec.get('dependency_images', []):
-            if d['container_image_name'] in dep_images:
-                d['container_image_url'] = dep_images[d['container_image_name']]
+            dep_name = d['container_image_name']
+            if dep_name in dep_images:
+                # Already processed this dependency - reuse cached values
+                cached = dep_images[dep_name]
+                if 'container_image_urls' in cached:
+                    d['container_image_urls'] = cached['container_image_urls']
+                if 'container_image_url' in cached:
+                    d['container_image_url'] = cached['container_image_url']
             else:
-                # upload container
-                dep_img = os.path.join(export_dir, d['container_image_url'])
-                d['container_image_url'] = "{}/{}".format(code_bucket_url, d['container_image_url'])
-                if args.skip_include_dependency_images:
-                    logger.info(f"Skipping upload of dependency image: {dep_img}.")
-                else:
-                    put(dep_img, d['container_image_url'])
-                dep_images[d['container_image_name']] = d['container_image_url']
+                # Handle multi-arch dependency images
+                if d.get('container_image_urls'):
+                    try:
+                        urls_dict = json.loads(d['container_image_urls'])
+                        unique_files = set(urls_dict.values())
+                        uploaded_urls = {}
+                        for filename in unique_files:
+                            dep_img = os.path.join(export_dir, filename)
+                            s3_url = "{}/{}".format(code_bucket_url, filename)
+                            if args.skip_include_dependency_images:
+                                logger.info(f"Skipping upload of dependency image: {dep_img}")
+                            else:
+                                logger.info(f"Uploading dependency image: {filename} to {s3_url}")
+                                put(dep_img, s3_url)
+                            uploaded_urls[filename] = s3_url
+                        
+                        # Update urls dict with S3 URLs
+                        updated_urls = {}
+                        for arch, filename in urls_dict.items():
+                            updated_urls[arch] = uploaded_urls[filename]
+                        d['container_image_urls'] = json.dumps(updated_urls)
+                        dep_images[dep_name] = {'container_image_urls': d['container_image_urls']}
+                    except (json.JSONDecodeError, AttributeError) as e:
+                        logger.error(f"Failed to parse container_image_urls field for dependency: {e}")
+                # Handle legacy single-arch dependency images
+                elif d.get('container_image_url'):
+                    dep_img = os.path.join(export_dir, d['container_image_url'])
+                    d['container_image_url'] = "{}/{}".format(code_bucket_url, d['container_image_url'])
+                    if args.skip_include_dependency_images:
+                        logger.info(f"Skipping upload of dependency image: {dep_img}")
+                    else:
+                        put(dep_img, d['container_image_url'])
+                    dep_images[dep_name] = {'container_image_url': d['container_image_url']}
 
         indexed_job_spec = mozart_es.index_document(index=JOB_SPECS_INDEX, body=job_spec, id=job_spec['id'])
         logger.debug(indexed_job_spec)

--- a/sdscli/adapters/hysds/pkg.py
+++ b/sdscli/adapters/hysds/pkg.py
@@ -290,10 +290,22 @@ def rm(args):
     cont_info = cont_info['_source']
     logger.debug(f"cont_info: {json.dumps(cont_info, indent=2)}")
 
-    if cont_info['url']:
+    # Delete all architecture-specific containers if urls field exists
+    if cont_info.get('urls'):
+        try:
+            urls_dict = json.loads(cont_info['urls'])
+            # Get unique URLs (avoid deleting same URL multiple times)
+            unique_urls = set(urls_dict.values())
+            for url in unique_urls:
+                logger.info(f"Deleting container: {url}")
+                rmall(url)  # delete container from code bucket and ES
+        except (json.JSONDecodeError, AttributeError) as e:
+            logger.error(f"Failed to parse urls field: {e}")
+    # Fallback to legacy url field for backward compatibility
+    elif cont_info.get('url'):
         rmall(cont_info['url'])  # delete container from code bucket and ES
     else:
-        logger.info(f"url is empty so skipping deletion of container from code bucket")
+        logger.info(f"No container URLs found, skipping deletion from code bucket")
 
     deleted_container = mozart_es.delete_by_id(index=CONTAINERS_INDEX, id=cont_info['id'])
     logger.debug(deleted_container)

--- a/sdscli/adapters/hysds/pkg.py
+++ b/sdscli/adapters/hysds/pkg.py
@@ -290,7 +290,10 @@ def rm(args):
     cont_info = cont_info['_source']
     logger.debug(f"cont_info: {json.dumps(cont_info, indent=2)}")
 
-    rmall(cont_info['url'])  # delete container from code bucket and ES
+    if cont_info['url']:
+        rmall(cont_info['url'])  # delete container from code bucket and ES
+    else:
+        logger.info(f"url is empty so skipping deletion of container from code bucket")
 
     deleted_container = mozart_es.delete_by_id(index=CONTAINERS_INDEX, id=cont_info['id'])
     logger.debug(deleted_container)

--- a/sdscli/command_line.py
+++ b/sdscli/command_line.py
@@ -363,6 +363,8 @@ def main():
                                    help="register git branch instead of release")
     parser_ci_add_job.add_argument(
         '--token', '-k', action='store_true', help="use configured OAuth token")
+    parser_ci_add_job.add_argument(
+        '--pipeline', '-p', action='store_true', help="import as Jenkins pipeline job")
     parser_ci_remove_job = parser_ci_subparsers.add_parser(
         'remove_job', help="remove Jenkins job")
     parser_ci_remove_job.add_argument('repo', help='git repository url')


### PR DESCRIPTION
### Overview
This PR adds comprehensive multi-architecture container support to sdscli and introduces Jenkins pipeline job integration, enabling HySDS to build, manage, and deploy containers for both **linux/amd64** (x86_64) and **linux/arm64** (ARM64/aarch64) architectures.

### Changes

#### 1. Multi-Architecture Package Management

**Updated [sdscli/adapters/hysds/pkg.py](cci:7://file:///Users/mcayanan/git/sdscli/sdscli/adapters/hysds/pkg.py:0:0-0:0):**
- Enhanced [rm](cci:1://file:///Users/mcayanan/git/sdscli/sdscli/adapters/hysds/pkg.py:280:0-353:38) function to handle multi-architecture container deletion
- Parses the new `urls` JSON field containing architecture-specific container URLs
- Deletes all unique container URLs (both x86_64 and ARM64 variants)
- Falls back to legacy `url` field for backward compatibility
- Prevents orphaned ARM64 containers from accumulating in code bucket

#### 2. Jenkins Pipeline Job Support

**Command Line Interface ([sdscli/command_line.py](cci:7://file:///Users/mcayanan/git/sdscli/sdscli/command_line.py:0:0-0:0)):**
- Added `--pipeline` / `-p` flag to `sds ci add_job` command
- Enables importing Jenkins jobs as pipeline jobs instead of freestyle jobs

**CI Adapter ([sdscli/adapters/hysds/ci.py](cci:7://file:///Users/mcayanan/git/sdscli/sdscli/adapters/hysds/ci.py:0:0-0:0)):**
- Passes pipeline flag to fabric tasks for job creation

**Fabric Tasks ([sdscli/adapters/hysds/fabfile.py](cci:7://file:///Users/mcayanan/git/sdscli/sdscli/adapters/hysds/fabfile.py:0:0-0:0)):**
- Updated `add_ci_job` and `get_ci_job_info` functions to support pipeline mode
- Selects appropriate Jenkins configuration template based on pipeline flag

**Jenkins Configuration Template ([files/config-pipeline.xml](cci:7://file:///Users/mcayanan/git/sdscli/sdscli/adapters/hysds/files/config-pipeline.xml:0:0-0:0)):**
- New template for Jenkins pipeline jobs
- Configures job to use repository's Jenkinsfile for build definition
- Includes parameterized build support with template variables:
  - `BUILD_MODE` - Choice: multi-platform, amd64-only, arm64-only
  - OAuth tokens for Git access
  - Container builder configuration
  - Mozart/GRQ REST API endpoints
  - Container registry settings
  - Storage URLs
- Supports GitHub push triggers
- Configurable Jenkinsfile path (default: `conf/sds/files/Jenkinsfile`)

#### 3. Example Files and Documentation

**Added [files/Jenkinsfile.example](cci:7://file:///Users/mcayanan/git/sdscli/sdscli/adapters/hysds/files/Jenkinsfile.example:0:0-0:0):**
- Generic example Jenkinsfile for multi-architecture container builds
- Demonstrates complete build workflow:
  - Parallel multi-platform builds (amd64 + arm64)
  - Single-architecture builds
  - Multi-platform manifest creation
  - Metadata publishing to Mozart and GRQ
  - Test artifact collection and reporting
- Includes TODO comments for project-specific customization
- Removed hardcoded project-specific build arguments

**Added [files/README.md](cci:7://file:///Users/mcayanan/git/sdscli/sdscli/adapters/hysds/files/README.md:0:0-0:0):**
- Comprehensive documentation for Jenkins pipeline setup
- Usage instructions for example files
- Customization guide for projects
- Jenkins parameter reference
- Build mode explanations

### Usage

**Add CI job as Jenkins pipeline:**
```bash
sds ci add_job <repo-url> <storage-type> --branch <branch> --pipeline
```

**Traditional freestyle job (default):**
```bash
sds ci add_job <repo-url> <storage-type> --branch <branch>
```

**Remove container package (multi-arch aware):**
```bash
sds pkg rm <container-id>
```

### Backward Compatibility ✅

**Multi-architecture support:**
- New multi-arch containers: Deletes both x86_64 and ARM64 variants from `urls` field
- Legacy single-arch containers: Falls back to `url` field (existing behavior)
- No breaking changes to existing workflows

**Jenkins jobs:**
- Without `--pipeline` flag: Creates traditional freestyle jobs (existing behavior)
- With `--pipeline` flag: Creates pipeline jobs using repository's Jenkinsfile
- Existing freestyle jobs continue to work unchanged

### Benefits

**Multi-architecture container management:**
- Complete cleanup of all container variants when removing packages
- No orphaned ARM64 containers in code bucket
- Simplified container lifecycle management
- Proper handling of architecture-specific URLs

**Jenkins pipeline support:**
- Modern Jenkins pipeline features (stages, parallel execution, Blue Ocean UI)
- Version-controlled build definitions in project repositories
- Declarative syntax for clearer build processes
- Better visibility and debugging capabilities
- Parameterized builds with sensible defaults

**Developer experience:**
- Generic, reusable example files
- Clear documentation and customization guides
- Reduced project-specific configuration in sdscli
- Projects own their CI/CD definitions

### Testing

- ✅ Deletion of multi-arch containers (both variants removed)
- ✅ Deletion of legacy single-arch containers (backward compatible)
- ✅ Pipeline job creation with `--pipeline` flag
- ✅ Freestyle job creation without flag (backward compatible)
- ✅ Jenkins parameter templating
- ✅ Jenkinsfile execution in pipeline jobs

### Related Changes

This PR works in conjunction with the HySDS multi-architecture initiative:
- **container-builder**: Adds `urls` field with architecture-specific URLs
- **hysds**: Container resolution based on worker architecture
- **hysds_commons**: Job spec resolution with multi-arch support
- **mozart**: API endpoints for multi-arch container metadata

---

**Dependencies:** Part of HySDS multi-architecture initiative  
**Breaking Changes:** None - fully backward compatible