### PR TITLE
HC-632: Fixed sds pkg export command to properly set the legacy url field

### DIFF
--- a/sdscli/__init__.py
+++ b/sdscli/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __url__ = "https://github.com/hysds/sdscli"
 __description__ = "Command line interface for SDSKit"

--- a/sdscli/adapters/hysds/pkg.py
+++ b/sdscli/adapters/hysds/pkg.py
@@ -80,8 +80,8 @@ def export(args):
             cont_info['urls'] = json.dumps(updated_urls)
         except (json.JSONDecodeError, AttributeError) as e:
             logger.error(f"Failed to parse urls field: {e}")
-    elif cont_info.get('url', None) != None:
-        # Legacy single-arch container
+    if cont_info.get('url', None) != None:
+        # Legacy single-arch container or backwards compatibility for multi-arch
         get(cont_info['url'], export_dir)
         cont_info['url'] = os.path.basename(cont_info['url'])
 
@@ -290,8 +290,8 @@ def import_pkg(args):
             cont_info['urls'] = json.dumps(updated_urls)
         except (json.JSONDecodeError, AttributeError) as e:
             logger.error(f"Failed to parse urls field: {e}")
-    elif cont_info.get('url', None) != None:
-        # Legacy single-arch container
+    if cont_info.get('url', None) != None:
+        # Legacy single-arch container or backwards compatibility for multi-arch
         cont_image = os.path.join(export_dir, cont_info['url'])
         cont_info['url'] = "{}/{}".format(code_bucket_url, cont_info['url'])
         put(cont_image, cont_info['url'])


### PR DESCRIPTION
This PR fixes a bug in the sds pkg export command so that it can properly set the legacy `url` field to just the basename of the tar package file name. Previously, it was set to the full S3 url. Here's an example of what was seen in the manifest.json of the SDS package:

```
(mozart) [hysdsops@ip-100-104-3-76 tmp]$ more container-hysds_lightweight-jobs-v2.0.2.sdspkg/manifest.json 
{
  "containers": {
    "digest": "sha256:1b6868aee5ec5b43c6b72d1438879005491e76355901982f2e4b3cc356cf3d98",
    "id": "container-hysds_lightweight-jobs:v2.0.2",
    "url": "s3://swot-dev-cc-fwd-pop/container-hysds_lightweight-jobs-v2.0.2.tar.gz",
    "urls": "{\"x86_64\": \"container-hysds_lightweight-jobs-v2.0.2.tar.gz\", \"amd64\": \"container-hysds_lightweight-jobs-v2.0.2.tar.gz\", \"arm64\": \"container-hysds_lightweight-jobs-v2.0.2-arm64.tar.gz\", \"aarch64\": \"container-hysds_li
ghtweight-jobs-v2.0.2-arm64.tar.gz\"}",
    "version": "v2.0.2"
  },
...
```


**Testing**

After performing an `sds pkg export` command on the lightweight jobs package, I examined the mainfest.json file in the sdspkg file and verified that `url` contained just the file name now:

```
(mozart) [hysdsops@ip-100-104-3-76 tmp]$ more container-hysds_lightweight-jobs-v2.0.2.sdspkg/manifest.json 
{
  "containers": {
    "digest": "sha256:1b6868aee5ec5b43c6b72d1438879005491e76355901982f2e4b3cc356cf3d98",
    "id": "container-hysds_lightweight-jobs:v2.0.2",
    "url": "container-hysds_lightweight-jobs-v2.0.2.tar.gz",
    "urls": "{\"x86_64\": \"container-hysds_lightweight-jobs-v2.0.2.tar.gz\", \"amd64\": \"container-hysds_lightweight-jobs-v2.0.2.tar.gz\", \"arm64\": \"container-hysds_lightweight-jobs-v2.0.2-arm64.tar.gz\", \"aarch64\": \"container-hysds_li
ghtweight-jobs-v2.0.2-arm64.tar.gz\"}",
    "version": "v2.0.2"
  },
  "hysds_ios": [
    {
      "id": "hysds-io-lightweight-echo:v2.0.2",
      "job-specification": "job-lightweight-echo:v2.0.2",
      "job-version": "v2.0.2",
      "label": "echo",
      "params": [
        {
          "from": "value",
          "name": "echo_var",
          "value": "Hello world!"
        }
      ],
      "resource": "hysds-io-specification",
      "submission_type": "individual"
    },

```